### PR TITLE
fix: remove invalid package names from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,23 +34,13 @@ RUN dnf update -y && \
         libXrandr \
         libxkbcommon \
         libXScrnSaver \
-        libXss \
         # Audio support
         alsa-lib \
         # Font support
         fontconfig \
         liberation-fonts \
         # Additional dependencies for browser automation
-        mesa-libgbm \
-        libgtk-3-0 \
-        libnss3 \
-        libxrandr2 \
-        libdrm2 \
-        libxkbcommon0 \
-        libxcomposite1 \
-        libxdamage1 \
-        libxss1 \
-        libasound2 && \
+        mesa-libgbm && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 


### PR DESCRIPTION
This PR fixes the Docker build failure by removing invalid package names from the Dockerfile.

## Changes
- Removed `libXss` (doesn't exist - `libXScrnSaver` already provides this functionality)
- Removed Debian-specific packages that don't exist in Amazon Linux dnf repos
- Kept only valid Red Hat/Fedora packages available in Amazon Linux

Fixes #1

Generated with [Claude Code](https://claude.ai/code)