### PR TITLE
fix: resolve Docker build failure with curl package conflict

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0
 RUN dnf update -y && \
     dnf install -y \
         wget \
-        curl \
         ca-certificates \
         findutils \
         binutils \


### PR DESCRIPTION
Fixes the Docker build failure caused by curl package conflicts in Amazon Linux.

The issue was that the Dockerfile was trying to install the full `curl` package, which conflicts with `curl-minimal` that's already present in the Amazon Linux base image. Removed the explicit curl installation since curl-minimal provides the same functionality.

Fixes #3

Generated with [Claude Code](https://claude.ai/code)