### PR TITLE
fix: remove invalid --verbose flag from playwright install command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,7 @@ RUN echo "Installing Playwright browsers..." && \
     echo "Installing Chromium browser..." && \
     PLAYWRIGHT_BROWSERS_PATH=${PLAYWRIGHT_BROWSERS_PATH} \
     PYTHONPATH=${LAMBDA_TASK_ROOT} \
-    python -m playwright install chromium --with-deps --verbose && \
+    python -m playwright install chromium --with-deps && \
     echo "Browser installation completed, verifying..." && \
     ls -la ${PLAYWRIGHT_BROWSERS_PATH}/ && \
     echo "Searching for Chromium files..." && \


### PR DESCRIPTION
Fixes Docker build failure where playwright install was failing due to the --verbose flag not being a valid option for the command.

Closes #9

Generated with [Claude Code](https://claude.ai/code)