### PR TITLE
fix: improve Playwright version detection using importlib.metadata fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,11 +88,21 @@ RUN echo "Verifying Playwright installation..." && \
     PYTHONPATH=${LAMBDA_TASK_ROOT} python - <<'PY'
 import sys, pathlib
 import playwright
-version = getattr(playwright, '__version__', 'unknown')
+import importlib.metadata as im
+
+# Try multiple methods to get Playwright version
+version = getattr(playwright, '__version__', None)
+if version is None:
+    try:
+        version = im.version('playwright')
+    except Exception:
+        version = 'unknown'
+
 print('Python version:', sys.version)
 print('Python path:', sys.path[:3])
 print('✅ Playwright imported successfully, version:', version)
 print('Playwright location:', pathlib.Path(playwright.__file__).resolve())
+
 if version == 'unknown':
     print('❌ Warning: Playwright version is unknown; this may cause import issues')
     sys.exit(1)

--- a/src/unfurl_processor/scrapers/playwright_scraper.py
+++ b/src/unfurl_processor/scrapers/playwright_scraper.py
@@ -31,7 +31,15 @@ try:
     # Try importing playwright base module first
     import playwright
 
-    version = getattr(playwright, "__version__", "unknown")
+    # Try multiple methods to get Playwright version
+    version = getattr(playwright, "__version__", None)
+    if version is None:
+        try:
+            import importlib.metadata as im
+            version = im.version("playwright")
+        except Exception:
+            version = "unknown"
+    
     import_logger.info(f"✅ Base playwright module imported, version: {version}")
     import_logger.info(f"Playwright location: {playwright.__file__}")
 

--- a/test_playwright_fix.py
+++ b/test_playwright_fix.py
@@ -14,7 +14,16 @@ def test_playwright_imports():
         # Test 1: Base playwright import
         print("1. Testing base playwright import...")
         import playwright
-        version = getattr(playwright, '__version__', 'unknown')
+        
+        # Try multiple methods to get Playwright version
+        version = getattr(playwright, '__version__', None)
+        if version is None:
+            try:
+                import importlib.metadata as im
+                version = im.version('playwright')
+            except Exception:
+                version = 'unknown'
+        
         print(f"   ✅ playwright imported successfully, version: {version}")
         
         # Test 2: async_api import (this was failing)


### PR DESCRIPTION
This PR fixes the Playwright version detection failure during Docker build by implementing a robust fallback mechanism.

## Problem
The Docker build was failing because the verification script could not detect the Playwright version - `playwright.__version__` returned "unknown" instead of the expected "1.45.x".

## Solution
- Updated Dockerfile verification script to use `importlib.metadata.version()` as fallback
- Applied same fix to playwright_scraper.py for consistency
- Updated test script to use robust version detection

## Changes
- `Dockerfile`: Enhanced Playwright version detection logic
- `src/unfurl_processor/scrapers/playwright_scraper.py`: Applied consistent version detection
- `test_playwright_fix.py`: Updated test logic

Fixes #17

Generated with [Claude Code](https://claude.ai/code)