### PR TITLE
fix(infra): include observability in event router ZIP and correct handler path

### DIFF
--- a/cdk/stacks/unfurl_service_stack.py
+++ b/cdk/stacks/unfurl_service_stack.py
@@ -114,8 +114,10 @@ class UnfurlServiceStack(Stack):
             function_name="unfurl-event-router",
             runtime=lambda_.Runtime.PYTHON_3_12,
             architecture=lambda_.Architecture.ARM_64,
-            handler="handler.lambda_handler",
-            code=lambda_.Code.from_asset("src/event_router"),
+            handler="event_router.handler.lambda_handler",
+            # Package the entire src tree so internal packages like `observability`
+            # are available to the function at runtime.
+            code=lambda_.Code.from_asset("src"),
             environment={
                 "SNS_TOPIC_ARN": unfurl_topic.topic_arn,
                 "SLACK_SECRET_NAME": slack_secret.secret_name,


### PR DESCRIPTION
This PR fixes a runtime import error in the ZIP-based event router Lambda.\n\nProblem\n- Lambda failed during init with: Runtime.ImportModuleError: No module named 'observability'\n- Cause: The function asset bundled only 'src/event_router/', excluding top-level packages like 'observability'.\n\nChanges\n- Handler: set to 'event_router.handler.lambda_handler'\n- Packaging: bundle the entire 'src/' directory so 'observability' (and other shared modules) are present at runtime\n- File: cdk/stacks/unfurl_service_stack.py\n\nRationale\n- Ensures the 'observability' package is available on Lambda's PYTHONPATH.\n- No application logic changes; strictly infrastructure packaging and handler path fix.\n\nValidation\n- Local dev: ran 'uv run black .', 'uv run flake8 .', 'uv run mypy .', and 'uv run pytest' — all passed.\n\nDeployment impact\n- CDK synth/deploy will update the Lambda code asset; after deploy, the runtime import error should be resolved.\n\nFollow-ups\n- If desired, we can add a CDK unit test for the Function's handler/path and asset path to prevent regressions.