### PR TITLE
fix(security): harden Slack ingress and asset mirroring

### DIFF
--- a/src/event_router/handler.py
+++ b/src/event_router/handler.py
@@ -22,6 +22,7 @@ from opentelemetry.propagate import inject
 
 from observability import metrics as m
 from observability.logging import setup_logfire
+from unfurl_processor.url_utils import validate_instagram_url
 
 # Configure Logfire and bridge stdlib logging (with console output)
 setup_logfire(enable_console_output=True)
@@ -30,6 +31,7 @@ metrics = None  # consolidated metrics in Logfire
 
 # Default AWS region to use when creating clients (helps unit tests)
 DEFAULT_AWS_REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-2")
+EXPECTED_SLACK_SIGNATURE_LENGTH = 67
 
 
 def get_sns_client() -> BaseClient:
@@ -46,6 +48,23 @@ def verify_slack_signature(
     body: str, timestamp: str, signature: str, signing_secret: str
 ) -> bool:
     """Verify the Slack request signature."""
+    if not signature or not signing_secret:
+        logfire.warning("Missing Slack signature or signing secret")
+        return False
+
+    if (
+        not signature.startswith("v0=")
+        or len(signature) != EXPECTED_SLACK_SIGNATURE_LENGTH
+    ):
+        logfire.warning("Malformed Slack signature")
+        return False
+
+    try:
+        int(signature[3:], 16)
+    except ValueError:
+        logfire.warning("Malformed Slack signature")
+        return False
+
     # Check timestamp to prevent replay attacks
     try:
         request_timestamp = float(timestamp)
@@ -122,26 +141,36 @@ def _get_header(event: Dict[str, Any], name: str) -> str:
     return ""
 
 
+def _parse_body_dict(body_str: str) -> Dict[str, Any]:
+    if not body_str:
+        return {}
+
+    try:
+        body = json.loads(body_str)
+    except json.JSONDecodeError:
+        return {}
+
+    return body if isinstance(body, dict) else {}
+
+
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     """Lambda handler for Slack event routing."""
-    logfire.info("Received event", event=event)
+    body_str = _get_body_str(event)
+    body = _parse_body_dict(body_str)
+    event_data = body.get("event", {})
+    event_type = event_data.get("type") if isinstance(event_data, dict) else None
+    link_count = len(event_data.get("links", [])) if isinstance(event_data, dict) else 0
 
-    # Check if this is a URL verification challenge
-    body_str = _get_body_str(event) or "{}"
+    logfire.info(
+        "Received Slack request",
+        request_id=getattr(context, "aws_request_id", None),
+        body_type=body.get("type"),
+        event_type=event_type,
+        link_count=link_count,
+        is_base64_encoded=bool(event.get("isBase64Encoded")),
+    )
+
     try:
-        body = json.loads(body_str) if body_str else {}
-    except json.JSONDecodeError:
-        body = {}
-
-    if body.get("type") == "url_verification":
-        return {
-            "statusCode": 200,
-            "body": json.dumps({"challenge": body.get("challenge")}),
-        }
-
-    # Handle regular Slack events
-    try:
-        # Parse the request body
         # Get Slack signature headers
         slack_signature = _get_header(event, "X-Slack-Signature")
         slack_timestamp = _get_header(event, "X-Slack-Request-Timestamp")
@@ -155,6 +184,12 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         ):
             logfire.warning("Invalid Slack signature")
             return {"statusCode": 401, "body": json.dumps({"error": "Unauthorized"})}
+
+        if body.get("type") == "url_verification":
+            return {
+                "statusCode": 200,
+                "body": json.dumps({"challenge": body.get("challenge")}),
+            }
 
         # Process the event
         event_data = body.get("event", {})
@@ -173,7 +208,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             if channel_id == "COMPOSER":
                 logfire.info(
                     "Ignoring COMPOSER link_shared event",
-                    links=event_data.get("links", []),
+                    link_count=len(event_data.get("links", [])),
                 )
 
                 # metrics consolidated in Logfire; no CloudWatch EMF emission
@@ -188,12 +223,16 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             instagram_links = [
                 {
                     **link,
-                    "url": html.unescape(
-                        link.get("url", "")
-                    ),  # Decode HTML entities like &amp; -> &
+                    "url": decoded_url,
                 }
                 for link in links
-                if link.get("domain") in ["instagram.com", "www.instagram.com"]
+                if isinstance(link, dict)
+                and (
+                    decoded_url := html.unescape(
+                        link.get("url", "")
+                    )  # Decode HTML entities like &amp; -> &
+                )
+                and validate_instagram_url(decoded_url)
             ]
 
             if instagram_links:
@@ -235,7 +274,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
 
                 logfire.info(
                     "Published Instagram links to SNS",
-                    links=instagram_links,
+                    link_count=len(instagram_links),
                     channel=event_data.get("channel"),
                 )
 

--- a/src/unfurl_processor/asset_manager.py
+++ b/src/unfurl_processor/asset_manager.py
@@ -1,7 +1,9 @@
 import asyncio
 import hashlib
+import ipaddress
 import os
 from typing import Optional
+from urllib.parse import urlparse
 
 import boto3
 import httpx
@@ -15,6 +17,13 @@ CONTENT_TYPE_EXTENSIONS = {
     "image/png": "png",
     "image/webp": "webp",
 }
+ALLOWED_ASSET_HOST_SUFFIXES = (
+    "cdninstagram.com",
+    "fbcdn.net",
+    "fbsbx.com",
+    "instagram.fcdn.us",
+)
+MAX_ASSET_SIZE_BYTES = 10 * 1024 * 1024
 
 
 class AssetManager:
@@ -29,15 +38,68 @@ class AssetManager:
         ext = CONTENT_TYPE_EXTENSIONS.get(content_type.lower(), "jpg")
         return f"instagram/{post_id}/{url_hash}.{ext}"
 
+    def _is_allowed_asset_url(self, url: str) -> bool:
+        try:
+            parsed = urlparse(url)
+        except Exception:
+            return False
+
+        if parsed.scheme != "https":
+            return False
+
+        hostname = (parsed.hostname or "").rstrip(".").lower()
+        if not hostname:
+            return False
+
+        try:
+            ipaddress.ip_address(hostname)
+        except ValueError:
+            pass
+        else:
+            return False
+
+        return any(
+            hostname == suffix or hostname.endswith("." + suffix)
+            for suffix in ALLOWED_ASSET_HOST_SUFFIXES
+        )
+
     async def upload_image(self, url: str, post_id: str) -> Optional[str]:
         if not self.bucket_name:
             return None
 
         try:
-            response = await self.http_client.get(url, timeout=5.0)
+            if not self._is_allowed_asset_url(url):
+                logger.warning("Rejected asset URL outside allowlist: %s", url)
+                return None
+
+            response = await self.http_client.get(
+                url, timeout=5.0, follow_redirects=False
+            )
             response.raise_for_status()
 
             content_type = response.headers.get("Content-Type", "image/jpeg")
+            content_type = content_type.split(";", 1)[0].strip().lower()
+            if content_type not in CONTENT_TYPE_EXTENSIONS:
+                logger.warning(
+                    "Rejected asset with unsupported content type %s from %s",
+                    content_type,
+                    url,
+                )
+                return None
+
+            content_length = response.headers.get("Content-Length")
+            if content_length:
+                try:
+                    if int(content_length) > MAX_ASSET_SIZE_BYTES:
+                        logger.warning("Rejected oversized asset from %s", url)
+                        return None
+                except ValueError:
+                    logger.warning("Invalid asset Content-Length from %s", url)
+
+            if len(response.content) > MAX_ASSET_SIZE_BYTES:
+                logger.warning("Rejected oversized asset body from %s", url)
+                return None
+
             key = self._generate_key(post_id, url, content_type)
 
             await asyncio.to_thread(

--- a/src/unfurl_processor/handler_async.py
+++ b/src/unfurl_processor/handler_async.py
@@ -36,6 +36,7 @@ from .url_utils import (
     canonicalize_instagram_url,
     extract_instagram_id,
     get_cache_key,
+    validate_instagram_url,
 )
 
 # Type aliases for better readability
@@ -312,17 +313,23 @@ class AsyncUnfurlHandler:
     ) -> List[Dict[str, str]]:
         """Extract and validate Instagram links from Slack event."""
         instagram_links = []
+        seen_urls = set()
         for link in links:
-            url = link.get("url", "")
-            domain = link.get("domain", "")
+            if not isinstance(link, dict):
+                continue
 
-            if domain == "instagram.com" and any(
-                pattern in url for pattern in ["/p/", "/reel/", "/tv/"]
-            ):
-                canonical_url = self._canonicalize_instagram_url(url)
-                instagram_links.append(
-                    {"original_url": url, "canonical_url": canonical_url}
-                )
+            url = link.get("url", "")
+            if not validate_instagram_url(url):
+                continue
+
+            canonical_url = self._canonicalize_instagram_url(url)
+            if canonical_url in seen_urls:
+                continue
+
+            seen_urls.add(canonical_url)
+            instagram_links.append(
+                {"original_url": url, "canonical_url": canonical_url}
+            )
 
         return instagram_links
 

--- a/src/unfurl_processor/scrapers/manager.py
+++ b/src/unfurl_processor/scrapers/manager.py
@@ -12,6 +12,7 @@ from aws_lambda_powertools import Logger
 from observability import metrics as m
 
 from ..merge_utils import merge_instagram_results
+from ..url_utils import validate_instagram_url
 from .base import BaseScraper, ScrapingResult
 from .http_scraper import HttpScraper
 from .playwright_scraper import PlaywrightScraper
@@ -78,6 +79,15 @@ class ScraperManager:
         start_time = time.time()
         errors = []
         results = []
+
+        if not validate_instagram_url(url):
+            return ScrapingResult(
+                success=False,
+                error="Invalid Instagram URL",
+                method="manager_validation",
+                response_time_ms=self.measure_time(start_time),
+                data={"url": url},
+            )
 
         self.logger.info(f"🔍 Starting intelligent scraping for: {url}")
 

--- a/src/unfurl_processor/scrapers/playwright_scraper.py
+++ b/src/unfurl_processor/scrapers/playwright_scraper.py
@@ -279,6 +279,14 @@ class PlaywrightScraper(BaseScraper):
         """Scrape Instagram data using optimized Playwright automation."""
         start_time = time.time()
 
+        if not self.validate_instagram_url(url):
+            return ScrapingResult(
+                success=False,
+                error="Invalid Instagram URL",
+                method=self.name,
+                response_time_ms=self.measure_time(start_time),
+            )
+
         if not PLAYWRIGHT_AVAILABLE:
             return ScrapingResult(
                 success=False,

--- a/src/unfurl_processor/slack_formatter.py
+++ b/src/unfurl_processor/slack_formatter.py
@@ -14,6 +14,13 @@ class SlackFormatter:
     def __init__(self):
         self.logger = logger
 
+    def _escape_mrkdwn_text(self, value: str) -> str:
+        """Escape user-controlled text before inserting it into mrkdwn fields."""
+        if not value:
+            return ""
+
+        return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
     def format_unfurl_data(
         self, data: Optional[Dict[str, Any]]
     ) -> Optional[Dict[str, Any]]:
@@ -109,6 +116,7 @@ class SlackFormatter:
             caption = data.get("caption") or ""
             clean_caption = self._extract_clean_caption(caption)
             if clean_caption:
+                clean_caption = self._escape_mrkdwn_text(clean_caption)
                 blocks.append(
                     {
                         "type": "section",
@@ -160,19 +168,18 @@ class SlackFormatter:
             host = urllib.parse.urlparse(url).netloc.lower()
         except Exception:
             return False
-        allowed_hosts = (
-            "scontent.cdninstagram.com",
-            "video.cdninstagram.com",
-            "scontent-lga3-1.cdninstagram.com",
-            "video.xx.fbcdn.net",
+        allowed_host_suffixes = (
+            "cdninstagram.com",
+            "fbcdn.net",
             "instagram.fcdn.us",
         )
         return any(
-            host == h or host.endswith("." + h.split(".", 1)[-1]) for h in allowed_hosts
+            host == suffix or host.endswith("." + suffix)
+            for suffix in allowed_host_suffixes
         )
 
     def _build_header_text(self, data: Dict[str, Any]) -> str:
-        username = data.get("username") or "Instagram User"
+        username = self._escape_mrkdwn_text(data.get("username") or "Instagram User")
         is_verified = data.get("is_verified", False)
         username_text = f"*{username}*"
         if is_verified:
@@ -221,7 +228,7 @@ class SlackFormatter:
         """Format image/photo content with rich, Instagram-like layout using
         Block Kit."""
         # Extract metadata
-        username = data.get("username") or "Instagram User"
+        username = self._escape_mrkdwn_text(data.get("username") or "Instagram User")
         caption = data.get("caption") or ""
         likes = data.get("likes")
         comments = data.get("comments")
@@ -301,6 +308,7 @@ class SlackFormatter:
         # Caption (if available) - parse and clean the caption
         clean_caption = self._extract_clean_caption(caption)
         if clean_caption:
+            clean_caption = self._escape_mrkdwn_text(clean_caption)
             display_caption = (
                 clean_caption[:200] + "..."
                 if len(clean_caption) > 200
@@ -366,7 +374,7 @@ class SlackFormatter:
     ) -> Dict[str, Any]:
         """Create basic unfurl for fallback scenarios."""
         # Normalise potential None values to safe defaults
-        username = username or "Instagram User"
+        username = self._escape_mrkdwn_text(username or "Instagram User")
         caption = caption or ""
 
         # Get appropriate indicator and label for content type
@@ -378,7 +386,8 @@ class SlackFormatter:
         # Clean caption if available
         clean_caption = self._extract_clean_caption(caption)
         if clean_caption:
-            description = f'"{clean_caption[:150]}..."'
+            safe_caption = self._escape_mrkdwn_text(clean_caption)
+            description = f'"{safe_caption[:150]}..."'
         else:
             description = f"Instagram {content_label.lower()} content"
 
@@ -424,6 +433,8 @@ class SlackFormatter:
             data.get("description")
             or f"Instagram {content_label.lower()} content available"
         )
+        title = self._escape_mrkdwn_text(title)
+        description = self._escape_mrkdwn_text(description)
 
         return {
             "color": "#E4405F",
@@ -538,6 +549,7 @@ class SlackFormatter:
             is_fallback = data.get("is_fallback", False)
 
             blocks = []
+            username = self._escape_mrkdwn_text(username)
 
             # Header block
             header_text = (
@@ -569,6 +581,7 @@ class SlackFormatter:
 
             # Caption block
             if caption and not is_fallback:
+                caption = self._escape_mrkdwn_text(caption)
                 display_caption = (
                     caption[:500] + "..." if len(caption) > 500 else caption
                 )

--- a/src/unfurl_processor/url_utils.py
+++ b/src/unfurl_processor/url_utils.py
@@ -3,6 +3,49 @@
 from typing import Optional
 from urllib.parse import urlparse
 
+CANONICAL_INSTAGRAM_HOST = "www.instagram.com"
+INSTAGRAM_MEDIA_TYPES = {"p", "reel", "tv"}
+
+
+def _get_parsed_instagram_url(url: str):
+    if not isinstance(url, str) or not url:
+        return None
+
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return None
+
+    hostname = (parsed.hostname or parsed.netloc or "").lower()
+    if not hostname:
+        return None
+
+    return parsed, hostname
+
+
+def _is_instagram_hostname(hostname: str) -> bool:
+    return hostname == "instagram.com" or hostname.endswith(".instagram.com")
+
+
+def _get_instagram_media_parts(url: str) -> Optional[tuple[str, str]]:
+    parsed_url = _get_parsed_instagram_url(url)
+    if parsed_url is None:
+        return None
+
+    parsed, hostname = parsed_url
+    if not _is_instagram_hostname(hostname):
+        return None
+
+    path_parts = [part for part in parsed.path.split("/") if part]
+    if len(path_parts) != 2:
+        return None
+
+    media_type, media_id = path_parts[0].lower(), path_parts[1]
+    if media_type not in INSTAGRAM_MEDIA_TYPES or not media_id:
+        return None
+
+    return media_type, media_id
+
 
 def extract_instagram_id(url: str) -> Optional[str]:
     """
@@ -19,19 +62,12 @@ def extract_instagram_id(url: str) -> Optional[str]:
     Returns:
         Post ID if found, None otherwise
     """
-    try:
-        parsed = urlparse(url)
-        # Validate it's an Instagram domain first
-        if parsed.netloc not in ("instagram.com", "www.instagram.com", ""):
-            return None
-
-        path_parts = [p for p in parsed.path.split("/") if p]
-
-        if len(path_parts) >= 2 and path_parts[0] in ["p", "reel", "tv"]:
-            return path_parts[1]
+    media_parts = _get_instagram_media_parts(url)
+    if media_parts is None:
         return None
-    except Exception:
-        return None
+
+    _, media_id = media_parts
+    return media_id
 
 
 def canonicalize_instagram_url(url: str) -> str:
@@ -49,27 +85,24 @@ def canonicalize_instagram_url(url: str) -> str:
     Returns:
         Canonical URL for consistent cache keys
     """
-    try:
-        parsed = urlparse(url)
-
-        # If it doesn't have a scheme, return original (likely invalid)
-        if not parsed.scheme:
-            return url
-
-        # Ensure consistent netloc
-        netloc = parsed.netloc if parsed.netloc else "www.instagram.com"
-        if not netloc.startswith("www."):
-            netloc = "www." + netloc
-
-        # Build path without trailing slash for consistency
-        path = parsed.path.rstrip("/")
-        if not path:
-            path = "/"
-
-        return f"{parsed.scheme}://{netloc}{path}"
-    except Exception:
-        # Return original if parsing fails
+    parsed_url = _get_parsed_instagram_url(url)
+    if parsed_url is None:
         return url
+
+    parsed, hostname = parsed_url
+
+    # If it doesn't have a scheme, return original (likely invalid)
+    if not parsed.scheme:
+        return url
+
+    media_parts = _get_instagram_media_parts(url)
+    if media_parts is None:
+        return url
+
+    media_type, media_id = media_parts
+    netloc = CANONICAL_INSTAGRAM_HOST
+
+    return f"{parsed.scheme}://{netloc}/{media_type}/{media_id}"
 
 
 def validate_instagram_url(url: str) -> bool:
@@ -82,16 +115,15 @@ def validate_instagram_url(url: str) -> bool:
     Returns:
         True if valid Instagram post URL, False otherwise
     """
-    try:
-        parsed = urlparse(url)
-        # Check domain
-        if parsed.netloc not in ("instagram.com", "www.instagram.com"):
-            return False
-
-        # Check for valid post paths
-        return any(pattern in parsed.path for pattern in ("/p/", "/reel/", "/tv/"))
-    except Exception:
+    parsed_url = _get_parsed_instagram_url(url)
+    if parsed_url is None:
         return False
+
+    parsed, _ = parsed_url
+    if parsed.scheme != "https":
+        return False
+
+    return _get_instagram_media_parts(url) is not None
 
 
 def is_instagram_video_url(url: str) -> bool:

--- a/tests/test_async_handler.py
+++ b/tests/test_async_handler.py
@@ -142,6 +142,14 @@ class TestAsyncUnfurlHandler:
                 "url": "https://www.instagram.com/reel/XYZ789/",
                 "domain": "instagram.com",
             },
+            {
+                "url": "https://m.instagram.com/tv/DEF456/",
+                "domain": "example.com",
+            },
+            {
+                "url": "https://evil.com/p/MALICIOUS/",
+                "domain": "instagram.com",
+            },
             {"url": "https://example.com/test", "domain": "example.com"},
             {"url": "https://www.instagram.com/profile/", "domain": "instagram.com"},
         ]
@@ -157,6 +165,10 @@ class TestAsyncUnfurlHandler:
             {
                 "original_url": "https://www.instagram.com/reel/XYZ789/",
                 "canonical_url": "https://www.instagram.com/reel/XYZ789",
+            },
+            {
+                "original_url": "https://m.instagram.com/tv/DEF456/",
+                "canonical_url": "https://www.instagram.com/tv/DEF456",
             },
         ]
         assert result == expected

--- a/tests/test_event_router.py
+++ b/tests/test_event_router.py
@@ -5,7 +5,7 @@ import hashlib
 import hmac
 import json
 import time
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from moto import mock_secretsmanager, mock_sns
 
@@ -57,6 +57,18 @@ class TestEventRouter:
         invalid_sig = "v0=invalid_signature"
 
         assert verify_slack_signature(body, timestamp, invalid_sig, secret) is False
+
+    def test_verify_slack_signature_malformed(self):
+        """Test signature verification with malformed signature input."""
+        assert (
+            verify_slack_signature(
+                body="{}",
+                timestamp=str(int(time.time())),
+                signature="not-a-slack-signature",
+                signing_secret="test_secret",
+            )
+            is False
+        )
 
     def test_verify_slack_signature_old_timestamp(self):
         """Test signature verification with old timestamp."""
@@ -215,6 +227,37 @@ class TestEventRouter:
         assert json.loads(response["body"])["challenge"] == challenge
 
     @mock_secretsmanager
+    def test_lambda_handler_url_verification_requires_signature(self):
+        """Unsigned URL verification requests should be rejected."""
+        import boto3
+
+        sm = boto3.client("secretsmanager", region_name="us-east-2")
+        sm.create_secret(
+            Name="unfurl-service/slack",
+            SecretString=json.dumps(
+                {"signing_secret": "test_secret", "bot_token": "xoxb-test"}
+            ),
+        )
+
+        body = json.dumps({"type": "url_verification", "challenge": "abc123"})
+        event = {"body": body, "headers": {}}
+
+        with patch.dict(
+            "os.environ",
+            {
+                "SLACK_SECRET_NAME": "unfurl-service/slack",
+                "SNS_TOPIC_ARN": "arn:aws:sns:us-east-2:123456789012:test-topic",
+                "POWERTOOLS_METRICS_NAMESPACE": "UnfurlService",
+                "DISABLE_METRICS": "true",
+                "AWS_DEFAULT_REGION": "us-east-2",
+            },
+        ):
+            response = lambda_handler(event, MockLambdaContext())
+
+        assert response["statusCode"] == 401
+        assert json.loads(response["body"]) == {"error": "Unauthorized"}
+
+    @mock_secretsmanager
     @mock_sns
     def test_lambda_handler_link_shared_event(self):
         """Test handling link_shared event with Instagram URL."""
@@ -291,6 +334,83 @@ class TestEventRouter:
 
         assert response["statusCode"] == 200
         assert json.loads(response["body"]) == {"status": "ok"}
+
+    @mock_secretsmanager
+    def test_lambda_handler_link_shared_event_accepts_instagram_subdomains(self):
+        """Valid Instagram subdomains should still be published for processing."""
+        import boto3
+
+        sm = boto3.client("secretsmanager", region_name="us-east-2")
+        sm.create_secret(
+            Name="unfurl-service/slack",
+            SecretString=json.dumps(
+                {"signing_secret": "test_secret", "bot_token": "xoxb-test"}
+            ),
+        )
+
+        slack_event = {
+            "type": "event_callback",
+            "event": {
+                "type": "link_shared",
+                "channel": "C123456",
+                "message_ts": "1234567890.123456",
+                "unfurl_id": "Uf123456",
+                "links": [
+                    {
+                        "url": "https://m.instagram.com/p/ABC123/",
+                        "domain": "m.instagram.com",
+                    }
+                ],
+            },
+        }
+
+        body = json.dumps(slack_event)
+        timestamp = str(int(time.time()))
+        sig_basestring = f"v0:{timestamp}:{body}"
+        signature = (
+            "v0="
+            + hmac.new(
+                b"test_secret", sig_basestring.encode(), hashlib.sha256
+            ).hexdigest()
+        )
+
+        event = {
+            "body": body,
+            "headers": {
+                "X-Slack-Signature": signature,
+                "X-Slack-Request-Timestamp": timestamp,
+            },
+        }
+        mock_sns_client = MagicMock()
+
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "SLACK_SECRET_NAME": "unfurl-service/slack",
+                    "SNS_TOPIC_ARN": "arn:aws:sns:us-east-2:123456789012:test-topic",
+                    "POWERTOOLS_METRICS_NAMESPACE": "UnfurlService",
+                    "DISABLE_METRICS": "true",
+                    "AWS_DEFAULT_REGION": "us-east-2",
+                },
+            ),
+            patch(
+                "src.event_router.handler.get_sns_client", return_value=mock_sns_client
+            ),
+        ):
+            response = lambda_handler(event, MockLambdaContext())
+
+        assert response["statusCode"] == 200
+        mock_sns_client.publish.assert_called_once()
+        published_message = json.loads(
+            mock_sns_client.publish.call_args.kwargs["Message"]
+        )
+        assert published_message["links"] == [
+            {
+                "url": "https://m.instagram.com/p/ABC123/",
+                "domain": "m.instagram.com",
+            }
+        ]
 
     @mock_secretsmanager
     @mock_sns

--- a/tests/test_url_utils.py
+++ b/tests/test_url_utils.py
@@ -76,6 +76,12 @@ class TestCanonicalizeInstagramUrl:
         expected = "https://www.instagram.com/p/ABC123"
         assert canonicalize_instagram_url(url) == expected
 
+    def test_canonicalize_normalizes_instagram_subdomain(self):
+        """Instagram subdomains should normalize to the canonical host."""
+        url = "https://m.instagram.com/p/ABC123/"
+        expected = "https://www.instagram.com/p/ABC123"
+        assert canonicalize_instagram_url(url) == expected
+
     def test_canonicalize_preserves_path(self):
         """Test preservation of path structure."""
         url = "https://www.instagram.com/reel/XYZ456/"
@@ -101,6 +107,7 @@ class TestValidateInstagramUrl:
         """Test validation of post URL."""
         assert validate_instagram_url("https://www.instagram.com/p/ABC123/")
         assert validate_instagram_url("https://instagram.com/p/ABC123")
+        assert validate_instagram_url("https://m.instagram.com/p/ABC123/")
 
     def test_validate_reel_url(self):
         """Test validation of reel URL."""
@@ -114,6 +121,11 @@ class TestValidateInstagramUrl:
         """Test rejection of non-Instagram domains."""
         assert not validate_instagram_url("https://facebook.com/p/ABC123/")
         assert not validate_instagram_url("https://example.com/p/ABC123/")
+
+    def test_validate_rejects_non_https_and_extra_segments(self):
+        """Only direct HTTPS media URLs should be accepted."""
+        assert not validate_instagram_url("http://www.instagram.com/p/ABC123/")
+        assert not validate_instagram_url("https://www.instagram.com/p/ABC123/embed/")
 
     def test_validate_profile_url(self):
         """Test rejection of profile URLs."""

--- a/tests/unit/test_asset_manager.py
+++ b/tests/unit/test_asset_manager.py
@@ -57,7 +57,7 @@ async def test_upload_success(
     http_client: AsyncMock,
     to_thread_mock: AsyncMock,
 ) -> None:
-    request = httpx.Request("GET", "https://example.com/image.png")
+    request = httpx.Request("GET", "https://scontent.cdninstagram.com/image.png")
     response = httpx.Response(
         200,
         headers={"Content-Type": "image/png"},
@@ -86,7 +86,7 @@ async def test_upload_success(
 async def test_download_failure(
     asset_manager: AssetManager, s3_client: MagicMock, http_client: AsyncMock
 ) -> None:
-    request = httpx.Request("GET", "https://example.com/missing.jpg")
+    request = httpx.Request("GET", "https://scontent.cdninstagram.com/missing.jpg")
     http_client.get.side_effect = httpx.HTTPStatusError(
         "not found", request=request, response=httpx.Response(404, request=request)
     )
@@ -104,7 +104,7 @@ async def test_s3_upload_failure(
     http_client: AsyncMock,
     to_thread_mock: AsyncMock,
 ) -> None:
-    request = httpx.Request("GET", "https://example.com/image.jpg")
+    request = httpx.Request("GET", "https://scontent.cdninstagram.com/image.jpg")
     http_client.get.return_value = httpx.Response(
         200,
         headers={"Content-Type": "image/jpeg"},
@@ -120,3 +120,34 @@ async def test_s3_upload_failure(
     assert result is None
     s3_client.put_object.assert_called_once()
     to_thread_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_rejects_disallowed_asset_origin(
+    asset_manager: AssetManager, s3_client: MagicMock, http_client: AsyncMock
+) -> None:
+    result = await asset_manager.upload_image(
+        "https://example.com/image.jpg", "post123"
+    )
+
+    assert result is None
+    http_client.get.assert_not_called()
+    s3_client.put_object.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rejects_non_image_content_type(
+    asset_manager: AssetManager, s3_client: MagicMock, http_client: AsyncMock
+) -> None:
+    request = httpx.Request("GET", "https://scontent.cdninstagram.com/asset")
+    http_client.get.return_value = httpx.Response(
+        200,
+        headers={"Content-Type": "text/html"},
+        content=b"<html></html>",
+        request=request,
+    )
+
+    result = await asset_manager.upload_image(str(request.url), "post123")
+
+    assert result is None
+    s3_client.put_object.assert_not_called()

--- a/tests/unit/test_slack_formatter.py
+++ b/tests/unit/test_slack_formatter.py
@@ -1,0 +1,34 @@
+from src.unfurl_processor.slack_formatter import SlackFormatter
+
+
+def test_format_unfurl_escapes_slack_mrkdwn_sequences() -> None:
+    formatter = SlackFormatter()
+    unfurl = formatter.format_unfurl_data(
+        {
+            "username": "bad<!channel>",
+            "caption": "<!here> <https://evil.example|trusted> & #tag @user",
+            "image_url": "https://scontent.cdninstagram.com/image.jpg",
+            "url": "https://www.instagram.com/p/ABC123/",
+            "content_type": "photo",
+        }
+    )
+
+    assert unfurl is not None
+
+    header_text = unfurl["blocks"][1]["text"]["text"]
+    caption_text = unfurl["blocks"][2]["text"]["text"]
+
+    assert "<!channel>" not in header_text
+    assert "&lt;!channel&gt;" in header_text
+    assert "<!here>" not in caption_text
+    assert "<https://evil.example|trusted>" not in caption_text
+    assert "&lt;!here&gt;" in caption_text
+    assert "&lt;https://evil.example|trusted&gt;" in caption_text
+    assert "&amp;" in caption_text
+
+
+def test_video_host_validation_rejects_untrusted_fcdn_domains() -> None:
+    formatter = SlackFormatter()
+
+    assert formatter._is_instagram_video_url("https://video.xx.fbcdn.net/video.mp4")
+    assert not formatter._is_instagram_video_url("https://attacker.fcdn.us/video.mp4")


### PR DESCRIPTION
## Summary
- What: harden the Slack event router so signed `url_verification` requests are verified the same way as event callbacks, malformed signatures fail closed, and request logging no longer captures the full raw API Gateway payload.
- Why: prevent unauthenticated event injection, reduce noisy failure modes, and avoid leaking more request metadata than needed to observability.
- How: centralize strict Instagram URL validation across the router, async handler, and scrapers; restrict mirrored asset downloads to trusted Instagram/Facebook CDN hosts with HTTPS-only, no redirects, image content-type checks, and size limits; escape user-controlled mrkdwn in unfurls to block mention and misleading-link injection.
- Impact: closes the critical SSRF-style public asset copy path and the high-severity Slack/event validation gaps while still accepting legitimate Instagram subdomains such as `m.instagram.com`.

## Test plan
- [x] `uv run flake8 src/ tests/`
- [x] `uv run mypy src/`
- [x] `uv run pytest`

Made with [Cursor](https://cursor.com)