### PR TITLE
feat(assets): route new images through CloudFront (phase 1 of 2)

### DIFF
--- a/cdk/stacks/unfurl_service_stack.py
+++ b/cdk/stacks/unfurl_service_stack.py
@@ -54,12 +54,26 @@ class UnfurlServiceStack(Stack):
             time_to_live_attribute="ttl",
         )
 
-        # S3 bucket for persisted assets — private, accessed only via CloudFront OAC
+        # S3 bucket for persisted assets.
+        # Phased migration: the bucket remains public-read so that Slack
+        # messages posted *before* this deploy keep resolving their direct-S3
+        # URLs until the 30-day lifecycle rule clears those objects. New
+        # writes are already addressed via the CloudFront distribution
+        # below (see ASSETS_PUBLIC_BASE_URL), so nothing new enters Slack
+        # with a direct-S3 URL. A follow-up change after the 30-day window
+        # will flip BlockPublicAccess to BLOCK_ALL and drop
+        # public_read_access, leaving CloudFront+OAC as the only access path.
         assets_bucket = s3.Bucket(
             self,
             "UnfurlAssets",
             bucket_name=f"unfurl-assets-{env_name}",
-            block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
+            public_read_access=True,
+            block_public_access=s3.BlockPublicAccess(
+                block_public_acls=False,
+                block_public_policy=False,
+                ignore_public_acls=False,
+                restrict_public_buckets=False,
+            ),
             encryption=s3.BucketEncryption.S3_MANAGED,
             removal_policy=RemovalPolicy.DESTROY,
             auto_delete_objects=True,

--- a/cdk/stacks/unfurl_service_stack.py
+++ b/cdk/stacks/unfurl_service_stack.py
@@ -54,15 +54,6 @@ class UnfurlServiceStack(Stack):
             time_to_live_attribute="ttl",
         )
 
-        # S3 bucket for persisted assets.
-        # Phased migration: the bucket remains public-read so that Slack
-        # messages posted *before* this deploy keep resolving their direct-S3
-        # URLs until the 30-day lifecycle rule clears those objects. New
-        # writes are already addressed via the CloudFront distribution
-        # below (see ASSETS_PUBLIC_BASE_URL), so nothing new enters Slack
-        # with a direct-S3 URL. A follow-up change after the 30-day window
-        # will flip BlockPublicAccess to BLOCK_ALL and drop
-        # public_read_access, leaving CloudFront+OAC as the only access path.
         assets_bucket = s3.Bucket(
             self,
             "UnfurlAssets",

--- a/cdk/stacks/unfurl_service_stack.py
+++ b/cdk/stacks/unfurl_service_stack.py
@@ -75,9 +75,6 @@ class UnfurlServiceStack(Stack):
             ],
         )
 
-        # CloudFront distribution provides the permanent public URL that Slack's
-        # image proxy can revalidate against. Bucket stays private; OAC signs
-        # CloudFront-to-S3 requests with SigV4.
         assets_distribution = cloudfront.Distribution(
             self,
             "UnfurlAssetsCDN",

--- a/cdk/stacks/unfurl_service_stack.py
+++ b/cdk/stacks/unfurl_service_stack.py
@@ -13,6 +13,8 @@ from aws_cdk import (
     aws_secretsmanager as sm,
     aws_sqs as sqs,
     aws_ecr_assets as ecr_assets,
+    aws_cloudfront as cloudfront,
+    aws_cloudfront_origins as cloudfront_origins,
 )
 from constructs import Construct
 
@@ -52,18 +54,13 @@ class UnfurlServiceStack(Stack):
             time_to_live_attribute="ttl",
         )
 
-        # S3 bucket for persisted assets
+        # S3 bucket for persisted assets — private, accessed only via CloudFront OAC
         assets_bucket = s3.Bucket(
             self,
             "UnfurlAssets",
             bucket_name=f"unfurl-assets-{env_name}",
-            public_read_access=True,
-            block_public_access=s3.BlockPublicAccess(
-                block_public_acls=False,
-                block_public_policy=False,
-                ignore_public_acls=False,
-                restrict_public_buckets=False,
-            ),
+            block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
+            encryption=s3.BucketEncryption.S3_MANAGED,
             removal_policy=RemovalPolicy.DESTROY,
             auto_delete_objects=True,
             lifecycle_rules=[
@@ -71,6 +68,29 @@ class UnfurlServiceStack(Stack):
                     expiration=Duration.days(30),
                 )
             ],
+        )
+
+        # CloudFront distribution provides the permanent public URL that Slack's
+        # image proxy can revalidate against. Bucket stays private; OAC signs
+        # CloudFront-to-S3 requests with SigV4.
+        assets_distribution = cloudfront.Distribution(
+            self,
+            "UnfurlAssetsCDN",
+            comment=f"Unfurl assets CDN ({env_name})",
+            default_behavior=cloudfront.BehaviorOptions(
+                origin=cloudfront_origins.S3BucketOrigin.with_origin_access_control(
+                    assets_bucket
+                ),
+                viewer_protocol_policy=(
+                    cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS
+                ),
+                allowed_methods=cloudfront.AllowedMethods.ALLOW_GET_HEAD,
+                cached_methods=cloudfront.CachedMethods.CACHE_GET_HEAD,
+                cache_policy=cloudfront.CachePolicy.CACHING_OPTIMIZED,
+                compress=True,
+            ),
+            price_class=cloudfront.PriceClass.PRICE_CLASS_100,
+            enabled=True,
         )
 
         # SNS topic for async processing
@@ -228,6 +248,9 @@ class UnfurlServiceStack(Stack):
                 "PLAYWRIGHT_BROWSERS_PATH": "/var/task/playwright-browsers",
                 "PYTHONPATH": "/var/task:/var/runtime",
                 "ASSETS_BUCKET_NAME": assets_bucket.bucket_name,
+                "ASSETS_PUBLIC_BASE_URL": (
+                    f"https://{assets_distribution.distribution_domain_name}"
+                ),
             },
             timeout=Duration.minutes(5),  # Increased for Playwright browser startup
             memory_size=1024,  # Increased for browser automation

--- a/src/unfurl_processor/asset_manager.py
+++ b/src/unfurl_processor/asset_manager.py
@@ -30,7 +30,7 @@ class AssetManager:
     def __init__(self, http_client: Optional[httpx.AsyncClient] = None) -> None:
         self.s3_client = boto3.client("s3")
         self.bucket_name = os.environ.get("ASSETS_BUCKET_NAME", "")
-        self.region = os.environ.get("AWS_REGION", "us-east-1")
+        self.public_base_url = os.environ.get("ASSETS_PUBLIC_BASE_URL", "").rstrip("/")
         self.http_client = http_client or httpx.AsyncClient()
 
     def _generate_key(self, post_id: str, url: str, content_type: str) -> str:
@@ -64,7 +64,7 @@ class AssetManager:
         )
 
     async def upload_image(self, url: str, post_id: str) -> Optional[str]:
-        if not self.bucket_name:
+        if not self.bucket_name or not self.public_base_url:
             return None
 
         try:
@@ -111,7 +111,7 @@ class AssetManager:
                 CacheControl="max-age=31536000",
             )
 
-            return f"https://{self.bucket_name}.s3.{self.region}.amazonaws.com/{key}"
+            return f"{self.public_base_url}/{key}"
         except httpx.HTTPError as exc:
             logger.warning("Failed to download asset from %s: %s", url, exc)
             return None

--- a/tests/test_infrastructure_assets.py
+++ b/tests/test_infrastructure_assets.py
@@ -51,11 +51,14 @@ def test_assets_bucket_configuration(template: Template) -> None:
             }
         ]
     }
+    # Phased migration: bucket stays publicly-readable until the 30-day
+    # lifecycle clears objects referenced by pre-CloudFront Slack messages.
+    # A follow-up change flips these to True and drops public_read_access.
     assert bucket.get("PublicAccessBlockConfiguration") == {
-        "BlockPublicAcls": True,
-        "BlockPublicPolicy": True,
-        "IgnorePublicAcls": True,
-        "RestrictPublicBuckets": True,
+        "BlockPublicAcls": False,
+        "BlockPublicPolicy": False,
+        "IgnorePublicAcls": False,
+        "RestrictPublicBuckets": False,
     }
 
 
@@ -65,17 +68,32 @@ def match(template_and_match):
     return match
 
 
-def test_assets_bucket_is_private(template: Template, match: Match) -> None:
-    """Bucket policy grants access only to CloudFront via OAC, never to `*`."""
-    policies = template.find_resources("AWS::S3::BucketPolicy")
-    for policy in policies.values():
-        statements = policy["Properties"]["PolicyDocument"]["Statement"]
-        for statement in statements:
-            principal = statement.get("Principal", {})
-            if principal.get("AWS") == "*":
-                raise AssertionError(
-                    "Assets bucket policy must not grant access to Principal AWS:*"
-                )
+def test_assets_bucket_is_public_during_migration(
+    template: Template, match: Match
+) -> None:
+    """During the phased migration the bucket still grants public read so old
+    direct-S3 URLs in existing Slack messages keep resolving. The follow-up
+    PR after the lifecycle window will remove this statement."""
+    template.has_resource_properties(
+        "AWS::S3::BucketPolicy",
+        {
+            "PolicyDocument": match.object_like(
+                {
+                    "Statement": match.array_with(
+                        [
+                            match.object_like(
+                                {
+                                    "Action": "s3:GetObject",
+                                    "Effect": "Allow",
+                                    "Principal": {"AWS": "*"},
+                                }
+                            )
+                        ]
+                    )
+                }
+            )
+        },
+    )
 
 
 def test_cloudfront_distribution_uses_oac(template: Template, match: Match) -> None:
@@ -111,7 +129,12 @@ def test_cloudfront_distribution_uses_oac(template: Template, match: Match) -> N
 def test_assets_bucket_policy_grants_cloudfront(
     template: Template, match: Match
 ) -> None:
-    """The only bucket-policy statement should allow CloudFront service principal."""
+    """Bucket policy must include a CloudFront service-principal grant (OAC).
+
+    During the phased migration this statement coexists with the public-read
+    statement from `public_read_access=True`; after lockdown only this grant
+    will remain.
+    """
     template.has_resource_properties(
         "AWS::S3::BucketPolicy",
         {

--- a/tests/test_infrastructure_assets.py
+++ b/tests/test_infrastructure_assets.py
@@ -52,10 +52,10 @@ def test_assets_bucket_configuration(template: Template) -> None:
         ]
     }
     assert bucket.get("PublicAccessBlockConfiguration") == {
-        "BlockPublicAcls": False,
-        "BlockPublicPolicy": False,
-        "IgnorePublicAcls": False,
-        "RestrictPublicBuckets": False,
+        "BlockPublicAcls": True,
+        "BlockPublicPolicy": True,
+        "IgnorePublicAcls": True,
+        "RestrictPublicBuckets": True,
     }
 
 
@@ -65,8 +65,53 @@ def match(template_and_match):
     return match
 
 
-def test_assets_bucket_is_public(template: Template, match: Match) -> None:
-    template.resource_count_is("AWS::S3::BucketPolicy", 1)
+def test_assets_bucket_is_private(template: Template, match: Match) -> None:
+    """Bucket policy grants access only to CloudFront via OAC, never to `*`."""
+    policies = template.find_resources("AWS::S3::BucketPolicy")
+    for policy in policies.values():
+        statements = policy["Properties"]["PolicyDocument"]["Statement"]
+        for statement in statements:
+            principal = statement.get("Principal", {})
+            if principal.get("AWS") == "*":
+                raise AssertionError(
+                    "Assets bucket policy must not grant access to Principal AWS:*"
+                )
+
+
+def test_cloudfront_distribution_uses_oac(template: Template, match: Match) -> None:
+    template.resource_count_is("AWS::CloudFront::Distribution", 1)
+    template.resource_count_is("AWS::CloudFront::OriginAccessControl", 1)
+    template.has_resource_properties(
+        "AWS::CloudFront::OriginAccessControl",
+        {
+            "OriginAccessControlConfig": match.object_like(
+                {
+                    "OriginAccessControlOriginType": "s3",
+                    "SigningBehavior": "always",
+                    "SigningProtocol": "sigv4",
+                }
+            )
+        },
+    )
+    template.has_resource_properties(
+        "AWS::CloudFront::Distribution",
+        {
+            "DistributionConfig": match.object_like(
+                {
+                    "Enabled": True,
+                    "DefaultCacheBehavior": match.object_like(
+                        {"ViewerProtocolPolicy": "redirect-to-https"}
+                    ),
+                }
+            )
+        },
+    )
+
+
+def test_assets_bucket_policy_grants_cloudfront(
+    template: Template, match: Match
+) -> None:
+    """The only bucket-policy statement should allow CloudFront service principal."""
     template.has_resource_properties(
         "AWS::S3::BucketPolicy",
         {
@@ -78,7 +123,9 @@ def test_assets_bucket_is_public(template: Template, match: Match) -> None:
                                 {
                                     "Action": "s3:GetObject",
                                     "Effect": "Allow",
-                                    "Principal": {"AWS": "*"},
+                                    "Principal": {
+                                        "Service": "cloudfront.amazonaws.com"
+                                    },
                                 }
                             )
                         ]
@@ -100,3 +147,13 @@ def test_unfurl_processor_env_includes_assets_bucket(template: Template) -> None
     function_props = next(iter(functions.values()))["Properties"]
     variables = function_props.get("Environment", {}).get("Variables", {})
     assert variables.get("ASSETS_BUCKET_NAME") == {"Ref": bucket_id}
+
+    public_base_url = variables.get("ASSETS_PUBLIC_BASE_URL")
+    assert (
+        public_base_url is not None
+    ), "Expected ASSETS_PUBLIC_BASE_URL env var on unfurl processor"
+    # CDK builds the URL via Fn::Join referencing the distribution's domain name.
+    assert isinstance(public_base_url, dict) and "Fn::Join" in public_base_url, (
+        f"Expected ASSETS_PUBLIC_BASE_URL to reference the CloudFront domain, "
+        f"got {public_base_url!r}"
+    )

--- a/tests/test_infrastructure_assets.py
+++ b/tests/test_infrastructure_assets.py
@@ -51,9 +51,7 @@ def test_assets_bucket_configuration(template: Template) -> None:
             }
         ]
     }
-    # Phased migration: bucket stays publicly-readable until the 30-day
-    # lifecycle clears objects referenced by pre-CloudFront Slack messages.
-    # A follow-up change flips these to True and drops public_read_access.
+
     assert bucket.get("PublicAccessBlockConfiguration") == {
         "BlockPublicAcls": False,
         "BlockPublicPolicy": False,

--- a/tests/unit/test_asset_manager.py
+++ b/tests/unit/test_asset_manager.py
@@ -12,7 +12,7 @@ from src.unfurl_processor.asset_manager import AssetManager
 def s3_client(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     client = MagicMock()
     monkeypatch.setenv("ASSETS_BUCKET_NAME", "test-bucket")
-    monkeypatch.setenv("AWS_REGION", "us-west-2")
+    monkeypatch.setenv("ASSETS_PUBLIC_BASE_URL", "https://d123.cloudfront.net")
     monkeypatch.setattr(
         "src.unfurl_processor.asset_manager.boto3.client",
         MagicMock(return_value=client),
@@ -71,7 +71,7 @@ async def test_upload_success(
     expected_hash = hashlib.sha256(str(request.url).encode()).hexdigest()[:12]
     expected_key = f"instagram/post123/{expected_hash}.png"
 
-    assert result == f"https://test-bucket.s3.us-west-2.amazonaws.com/{expected_key}"
+    assert result == f"https://d123.cloudfront.net/{expected_key}"
     s3_client.put_object.assert_called_once_with(
         Bucket="test-bucket",
         Key=expected_key,
@@ -151,3 +151,25 @@ async def test_rejects_non_image_content_type(
 
     assert result is None
     s3_client.put_object.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_skips_upload_when_public_base_url_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    http_client: AsyncMock,
+    to_thread_mock: AsyncMock,
+) -> None:
+    monkeypatch.setenv("ASSETS_BUCKET_NAME", "test-bucket")
+    monkeypatch.delenv("ASSETS_PUBLIC_BASE_URL", raising=False)
+    monkeypatch.setattr(
+        "src.unfurl_processor.asset_manager.boto3.client",
+        MagicMock(return_value=MagicMock()),
+    )
+
+    manager = AssetManager(http_client=http_client)
+    result = await manager.upload_image(
+        "https://scontent.cdninstagram.com/image.jpg", "post123"
+    )
+
+    assert result is None
+    http_client.get.assert_not_called()


### PR DESCRIPTION
## Summary

**Phase 1 of 2** — route every *new* image through CloudFront while leaving the legacy public-read bucket in place so old Slack messages keep rendering. Phase 2 (tracking issue to follow) flips the bucket to fully private after the existing 30-day lifecycle rule has drained objects referenced by pre-deploy messages.

## Why phased

Slack messages posted before this deploy contain direct-S3 URLs like `https://unfurl-assets-prod.s3.us-east-2.amazonaws.com/...` in their unfurl `image_url`. Slack's `slack-imgs.com` proxy may revalidate those URLs over time. If the bucket went fully private today, those revalidations would 403 and thumbnails would break in older messages.

The bucket already has a 30-day `LifecycleRule` deleting every object. So any direct-S3 URL in a message older than 30 days is already broken — the object is gone. That gives us a self-draining cutover clock: freeze direct-S3 URLs today (this PR), wait for the lifecycle window to clear the referenced objects, then flip the bucket private (phase 2).

## How (this PR)

- **CloudFront distribution** ([cdk/stacks/unfurl_service_stack.py](cdk/stacks/unfurl_service_stack.py)): new `cloudfront.Distribution` using `S3BucketOrigin.with_origin_access_control()` (modern OAC, SigV4 origin signing). `PriceClass.PRICE_CLASS_100` because Slack fetches server-side. Processor Lambda gets a new `ASSETS_PUBLIC_BASE_URL` env var pointing at the distribution domain.
- **Bucket stays public-read** with BPA lenient — unchanged from `main`, plus explicit SSE-S3 as a no-op compliance signal. Two bucket-policy statements coexist: `Principal: "*"` (legacy) and `Principal: { Service: cloudfront.amazonaws.com }` + `aws:SourceArn` (OAC).
- **asset_manager** ([src/unfurl_processor/asset_manager.py](src/unfurl_processor/asset_manager.py)): returns `{ASSETS_PUBLIC_BASE_URL}/{key}` instead of the raw S3 URL. Skips upload if either env var is unset. Region field removed (no longer used).

## Impact

- **Security today:** no worse than `main`. Bucket still public, same keys, same surface.
- **Security after phase 2:** fully closed — BPA `BLOCK_ALL`, only CloudFront can read via OAC.
- **Old Slack thumbnails:** unaffected. Legacy direct-S3 URLs continue to resolve until their objects age out at day 30.
- **New Slack thumbnails:** served via CloudFront from day 0. Never break on revalidation, since CloudFront URLs do not expire.
- **Cost:** ~\$0.085/GB CloudFront egress (PRICE_CLASS_100). Few cents/month at this service's scale.
- **Deploy time:** CloudFront distribution takes ~15–20 min on first create.

## Phase 2 preview

Tracking issue will be opened alongside this PR. Summary of the follow-up change:

```python
block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
# remove: public_read_access=True
```

Plus revert test assertions to `test_assets_bucket_is_private`. No asset_manager changes needed — it's already writing CloudFront URLs.

## Testing

- `uv run pytest tests/unit/test_asset_manager.py` — 7/7 passing, including new `test_skips_upload_when_public_base_url_missing`.
- `RUN_CDK_TESTS=true uv run pytest tests/test_infrastructure_assets.py` — 5/5 passing. Covers: lifecycle rule, lenient BPA (asserted as all-False during migration), public-read bucket-policy statement still present, CloudFront distribution count + HTTPS redirect, OAC config (`s3` origin type, `always` signing, SigV4), CloudFront service-principal grant in bucket policy, Lambda env includes `ASSETS_PUBLIC_BASE_URL` referencing the distribution domain.
- `uv run black --check`, `uv run flake8`, `uv run mypy src/unfurl_processor/asset_manager.py` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)