### PR TITLE
fix(observability): fail open, unpin opentelemetry-api (restore event router)

### DIFF
--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -25,8 +25,10 @@ annotated-types==0.5.0
 orjson==3.10.12
 
 # Observability (Logfire)
+# Only pin logfire; its [aws-lambda] extras pick a consistent opentelemetry-*
+# family. Pinning opentelemetry-api in isolation forces pip to backtrack to
+# an old opentelemetry-instrumentation-aws-lambda that logfire 4.x can't use.
 logfire[aws-lambda]==4.1.0
-opentelemetry-api==1.22.0
 
 # Performance and browser automation (optional but recommended)
 uvloop==0.19.0

--- a/requirements-event-router.txt
+++ b/requirements-event-router.txt
@@ -11,5 +11,8 @@ typing-extensions==4.7.0
 wrapt==1.16.0
 
 # Observability (Logfire)
+# Only pin logfire; let its [aws-lambda] extras resolve the opentelemetry-*
+# family in lockstep. Pinning opentelemetry-api separately forced pip to
+# backtrack to a very old opentelemetry-instrumentation-aws-lambda that
+# logfire 4.x cannot import, crashing Lambda init.
 logfire[aws-lambda]==4.1.0
-opentelemetry-api==1.22.0

--- a/src/event_router/handler.py
+++ b/src/event_router/handler.py
@@ -24,8 +24,10 @@ from observability import metrics as m
 from observability.logging import setup_logfire
 from unfurl_processor.url_utils import validate_instagram_url
 
-# Configure Logfire and bridge stdlib logging (with console output)
-setup_logfire(enable_console_output=True)
+try:
+    setup_logfire(enable_console_output=True)
+except Exception as _setup_err:  # pragma: no cover - defensive
+    print(f"setup_logfire failed; continuing without Logfire: {_setup_err}")
 
 metrics = None  # consolidated metrics in Logfire
 
@@ -291,5 +293,11 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         }
 
 
-# Wrap handler with Logfire's AWS Lambda instrumentation (in-place)
-logfire.instrument_aws_lambda(lambda_handler)
+try:
+    logfire.instrument_aws_lambda(lambda_handler)
+except Exception as _instr_err:  # pragma: no cover - defensive
+    # Observability must fail open: a broken instrumentation dep must not
+    # crash Lambda init and take the event router offline.
+    print(
+        "logfire.instrument_aws_lambda failed; continuing without it: " f"{_instr_err}"
+    )

--- a/src/observability/metrics.py
+++ b/src/observability/metrics.py
@@ -3,37 +3,64 @@
 Creating instruments once here avoids duplicate "instrument already created"
 warnings that occur when instruments are instantiated across multiple modules.
 Import and use these instruments wherever metrics are recorded.
+
+Observability must fail open: if Logfire is not importable or instrument
+creation fails, we substitute no-op instruments so that call sites like
+`processing_errors.add(1)` remain safe without guards everywhere.
 """
 
 from __future__ import annotations
 
-import logfire
+
+class _NoOpInstrument:
+    """Stand-in for a Logfire metric instrument when creation fails."""
+
+    def add(self, *_args, **_kwargs) -> None:
+        return None
+
+    def record(self, *_args, **_kwargs) -> None:
+        return None
+
+
+def _counter(name: str):
+    try:
+        import logfire
+
+        return logfire.metric_counter(name)
+    except Exception:
+        return _NoOpInstrument()
+
+
+def _histogram(name: str, *, unit: str):
+    try:
+        import logfire
+
+        return logfire.metric_histogram(name, unit=unit)
+    except Exception:
+        return _NoOpInstrument()
+
 
 # Generic service-level metrics
-links_processed = logfire.metric_counter("links_processed")
-unfurls_generated = logfire.metric_counter("unfurls_generated")
-processing_errors = logfire.metric_counter("processing_errors")
+links_processed = _counter("links_processed")
+unfurls_generated = _counter("unfurls_generated")
+processing_errors = _counter("processing_errors")
 
-total_processing_time_ms = logfire.metric_histogram(
-    "total_processing_time_ms", unit="ms"
-)
+total_processing_time_ms = _histogram("total_processing_time_ms", unit="ms")
 
 # Instagram fetch/scraping metrics
-instagram_fetch_time_ms = logfire.metric_histogram("instagram_fetch_time_ms", unit="ms")
-instagram_fetch_success = logfire.metric_counter("instagram_fetch_success")
-instagram_fetch_errors = logfire.metric_counter("instagram_fetch_errors")
-scraping_method = logfire.metric_counter("scraping_method")
+instagram_fetch_time_ms = _histogram("instagram_fetch_time_ms", unit="ms")
+instagram_fetch_success = _counter("instagram_fetch_success")
+instagram_fetch_errors = _counter("instagram_fetch_errors")
+scraping_method = _counter("scraping_method")
 
 # Slack delivery metrics
-slack_unfurl_success = logfire.metric_counter("slack_unfurl_success")
-slack_unfurl_errors = logfire.metric_counter("slack_unfurl_errors")
-slack_api_errors = logfire.metric_counter("slack_api_errors")
+slack_unfurl_success = _counter("slack_unfurl_success")
+slack_unfurl_errors = _counter("slack_unfurl_errors")
+slack_api_errors = _counter("slack_api_errors")
 
 # ScraperManager metrics (minimal set)
-scraper_success = logfire.metric_counter("scraper_success")
-scraper_failure = logfire.metric_counter("scraper_failure")
-scraper_exception = logfire.metric_counter("scraper_exception")
-scraper_response_time_ms = logfire.metric_histogram(
-    "scraper_response_time_ms", unit="ms"
-)
-all_scrapers_failed = logfire.metric_counter("all_scrapers_failed")
+scraper_success = _counter("scraper_success")
+scraper_failure = _counter("scraper_failure")
+scraper_exception = _counter("scraper_exception")
+scraper_response_time_ms = _histogram("scraper_response_time_ms", unit="ms")
+all_scrapers_failed = _counter("all_scrapers_failed")

--- a/src/unfurl_processor/entrypoint.py
+++ b/src/unfurl_processor/entrypoint.py
@@ -33,8 +33,10 @@ from .handler_async import AsyncUnfurlHandler
 # Initialize observability tools
 logger = Logger()
 
-# Configure Logfire as the consolidated backend
-setup_logfire(enable_console_output=False)
+try:
+    setup_logfire(enable_console_output=False)
+except Exception as _setup_err:  # pragma: no cover - defensive
+    print(f"setup_logfire failed; continuing without Logfire: {_setup_err}")
 
 # Powertools metrics/tracer removed; using Logfire metrics and spans
 metrics_available = False
@@ -96,10 +98,16 @@ def lambda_handler(event: Dict[str, Any], context: LambdaContext) -> Dict[str, A
         }
 
 
-# Wrap handler with Logfire's AWS Lambda instrumentation (in-place)
-logfire.instrument_aws_lambda(
-    lambda_handler, event_context_extractor=extract_context_from_sns_event
-)
+try:
+    logfire.instrument_aws_lambda(
+        lambda_handler, event_context_extractor=extract_context_from_sns_event
+    )
+except Exception as _instr_err:  # pragma: no cover - defensive
+    # Observability must fail open: a broken instrumentation dep must not
+    # crash Lambda init and take the unfurl processor offline.
+    print(
+        "logfire.instrument_aws_lambda failed; continuing without it: " f"{_instr_err}"
+    )
 
 
 # No metrics decorator; metrics are handled by Logfire directly


### PR DESCRIPTION
## Summary

Restore service after PR #54's deploy silently dead-lettered every Slack `link_shared` event.

**Root cause (from CloudWatch):**

```
RuntimeError: `logfire.instrument_aws_lambda()` requires the
              `opentelemetry-instrumentation-aws-lambda` package.
  File "/var/task/event_router/handler.py", line 295, in <module>
      logfire.instrument_aws_lambda(lambda_handler)
```

The `EventRouterDeps` layer rebuilt during PR #54's deploy. `requirements-event-router.txt` pinned `opentelemetry-api==1.22.0` but `logfire[aws-lambda]==4.1.0` transitively requires a much newer `opentelemetry-instrumentation` family. Pip's resolver backtracked through ~20 versions and settled on `opentelemetry-instrumentation-aws-lambda==0.43b0` — the last version compatible with `opentelemetry-api==1.22.0`, but far too old for logfire 4.1.0's integration module to import. At runtime `logfire.instrument_aws_lambda(...)`, called at module top-level in `src/event_router/handler.py:295`, raised `RuntimeError` during Lambda init. Every invocation has returned `Runtime.Unknown`/502 since **2026-04-21 23:25 UTC**. No SNS messages were ever published, so the processor has also been idle (its last log is from before the deploy).

## Changes

**Part A — fail open at module import (immediate restoration)**

- `src/event_router/handler.py`: wrap `setup_logfire(...)` and `logfire.instrument_aws_lambda(lambda_handler)` in `try/except Exception`.
- `src/unfurl_processor/entrypoint.py`: same treatment — the processor image has the same broken dep stack and would crash on its next cold start otherwise.
- `src/observability/metrics.py`: each `metric_counter` / `metric_histogram` creation wrapped; failure yields a `_NoOpInstrument` so call sites like `processing_errors.add(1)` stay safe without guards everywhere.

**Part B — resolve the actual dep regression**

- Drop the isolated `opentelemetry-api==1.22.0` pin from `requirements-event-router.txt` and `requirements-docker.txt`. Letting `logfire[aws-lambda]==4.1.0`'s extras pick the whole `opentelemetry-*` family in one pass avoids pip's 20-step backtrack and gives us the versions logfire is actually built against.

## Why phased this way

Part A alone restores service — even if Part B's dep resolution still produced a mismatched family for some reason, the Lambda would still boot (just without tracing). Part B is the proper fix so observability also works. Shipping them together means a single deploy gets us both boot-worthy Lambdas *and* real telemetry.

## Impact

- Event router boots even if a future observability regression slips through.
- Processor boots on next cold start when SNS resumes delivery.
- Next deploy's layer build picks a coherent `opentelemetry-*` family.
- No behavior change for users once the Lambdas are healthy again.

## Testing

- `uv run pytest` — **77 passed, 5 skipped**
- `RUN_CDK_TESTS=true uv run pytest tests/test_infrastructure_assets.py` — **5 passed**
- `uv run black --check src/ tests/` — clean
- `uv run flake8` on modified files — clean
- `uv run mypy src/` — no issues

Post-deploy verification (what I'll check after CI green-lights):
- [ ] `aws logs tail /aws/lambda/unfurl-event-router --since 10m` shows `INIT_REPORT ... Status: success` (not `Status: error`).
- [ ] Post a Slack message with an Instagram URL and confirm the processor log stream receives an SNS record.
- [ ] Grep processor logs for `logfire.instrument_aws_lambda failed` — expected absence, but if present, at least Lambda booted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)