### PR TITLE
fix(deploy): use github oidc for aws deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
 
 env:
   AWS_REGION: us-east-2
@@ -60,8 +65,8 @@ jobs:
   deploy:
     needs: test
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -87,12 +92,14 @@ jobs:
       - name: Install AWS CDK
         run: npm install -g aws-cdk
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials with OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
+          role-session-name: unfurl-service-github-actions
+          role-duration-seconds: 3600
+          mask-aws-account-id: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- AWS CLI configured with credentials
+- AWS CLI configured with credentials for manual deployments
 - AWS CDK CLI (`npm install -g aws-cdk`)
 - Python 3.12+
 - Docker
@@ -10,13 +10,42 @@
 
 ## AWS Setup
 
-### 1. Configure GitHub Secrets
+### 1. Configure GitHub OIDC
 
-Add these to your GitHub repository (Settings -> Secrets -> Actions):
+Create or reuse an AWS IAM role that trusts GitHub Actions for this repository,
+then add its ARN to your GitHub repository (Settings -> Secrets and variables ->
+Actions -> Secrets):
 
-- `AWS_ACCESS_KEY_ID`
-- `AWS_SECRET_ACCESS_KEY`
+- `AWS_DEPLOY_ROLE_ARN`
 - `LOGFIRE_TOKEN` (optional, for observability)
+
+The role trust policy should allow the `willtech3/unfurl-service` repository to
+assume the role from the `main` branch:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<account-id>:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub": "repo:willtech3/unfurl-service:ref:refs/heads/main"
+        }
+      }
+    }
+  ]
+}
+```
+
+Attach the permissions required for CDK deployment in this account. The GitHub
+Actions workflow uses short-lived OIDC credentials and does not require
+`AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY`.
 
 ### 2. Store Slack Credentials
 
@@ -44,7 +73,9 @@ cdk bootstrap aws://ACCOUNT_ID/us-east-2
 
 ### Automated (Recommended)
 
-Push to `main` branch. GitHub Actions will:
+Push to the `main` branch or run the deploy workflow manually from the `main`
+ref. GitHub Actions will:
+
 1. Run tests
 2. Build container
 3. Deploy via CDK


### PR DESCRIPTION
What: Replace long-lived AWS access key configuration in the deploy workflow with GitHub OIDC role assumption and document the AWS_DEPLOY_ROLE_ARN setup.\n\nWhy: Short-lived federated credentials reduce secret sprawl and match the deployment approach used in the tldr repo.\n\nHow: Grant id-token permission, assume the configured AWS deploy role via aws-actions/configure-aws-credentials, allow manual workflow dispatch from main, and update deployment docs with the role trust policy shape.\n\nImpact: Main branch deployments now require the AWS_DEPLOY_ROLE_ARN GitHub secret and an AWS IAM role that trusts this repository's main ref. Long-lived AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are no longer needed for deployment.\n\nTesting: uv run pytest; uv run mypy src/; uv run flake8 .; git diff --check. black --check . still reports a pre-existing unrelated formatting issue in scripts/check-slack-config.py.