### PR TITLE
fix(deploy): fall back while OIDC role is configured

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,12 @@ jobs:
       - name: Install AWS CDK
         run: npm install -g aws-cdk
 
+      # Prefer short-lived OIDC credentials when AWS_DEPLOY_ROLE_ARN exists.
+      # Fall back to the existing main-only access-key secrets until the role is
+      # configured for this repository.
       - name: Configure AWS credentials with OIDC
+        id: configure-aws-oidc
+        continue-on-error: true
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
@@ -100,6 +105,15 @@ jobs:
           role-session-name: unfurl-service-github-actions
           role-duration-seconds: 3600
           mask-aws-account-id: true
+
+      - name: Configure AWS credentials with access keys
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+          mask-aws-account-id: true
+        if: steps.configure-aws-oidc.outcome != 'success'
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,8 +44,10 @@ assume the role from the `main` branch:
 ```
 
 Attach the permissions required for CDK deployment in this account. The GitHub
-Actions workflow uses short-lived OIDC credentials and does not require
-`AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY`.
+Actions workflow prefers short-lived OIDC credentials. Until
+`AWS_DEPLOY_ROLE_ARN` is configured, it falls back to the existing main-only
+`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` secrets so deployments stay
+unblocked during the migration.
 
 ### 2. Store Slack Credentials
 


### PR DESCRIPTION
## What
- Prefer AWS GitHub OIDC for deploy credentials when AWS_DEPLOY_ROLE_ARN is available.
- Fall back to the existing main-only AWS access key secrets when OIDC configuration fails.
- Update deployment docs to describe the migration behavior.

## Why
The current main deployment fails in the AWS credential step because AWS_DEPLOY_ROLE_ARN is not configured in this repository yet, leaving configure-aws-credentials with no role or key provider.

## How
The OIDC credentials step is marked continue-on-error and given an id. The access-key credential step runs only when the OIDC step does not succeed, matching the tldr transition pattern.

## Impact
Main deployments are unblocked while the OIDC role secret is added. Once AWS_DEPLOY_ROLE_ARN is configured and valid, deployments use short-lived OIDC credentials automatically.

## Testing
- uv run pytest
- git diff --check