### PR TITLE
fix(security): refresh vulnerable runtime dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # =====================================================
 # Using the official Playwright image ensures compatibility and includes all
 # necessary system dependencies (apt-get, etc.) for browser installation
-FROM --platform=linux/arm64 mcr.microsoft.com/playwright/python:v1.45.0-jammy as builder
+FROM --platform=linux/arm64 mcr.microsoft.com/playwright/python:v1.60.0-noble AS builder
 
 # Set environment variables for build stage
 ENV PYTHONUNBUFFERED=1
@@ -14,7 +14,7 @@ ENV DOCKER_BUILDKIT=1
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 # Install build dependencies for native extensions
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     gcc \
     g++ \
@@ -59,7 +59,7 @@ ENV PYTHONPATH=/var/task
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0
 
 # Install system dependencies needed for Playwright
-RUN dnf update -y && \
+RUN dnf upgrade -y && \
     dnf install -y \
         # Basic utilities
         wget \
@@ -75,15 +75,21 @@ RUN dnf update -y && \
         libXrandr \
         mesa-libgbm \
         alsa-lib && \
+    dnf upgrade -y && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
 # Copy installed Python packages from build stage
 COPY --from=builder /app ${LAMBDA_TASK_ROOT}
 
-# Fix greenlet for ARM64 Lambda runtime - reinstall with proper architecture
-RUN pip install --no-cache-dir --target ${LAMBDA_TASK_ROOT} --upgrade greenlet && \
-    echo "✅ Greenlet reinstalled for ARM64 compatibility"
+# Fix greenlet for ARM64 Lambda runtime and keep vulnerable base Python
+# libraries shadowed by patched packages in the Lambda task root.
+RUN pip install --no-cache-dir --target ${LAMBDA_TASK_ROOT} --upgrade \
+        greenlet==3.5.0 \
+        urllib3==2.7.0 && \
+    rm -rf /var/lang/lib/python3.12/site-packages/urllib3 \
+        /var/lang/lib/python3.12/site-packages/urllib3-*.dist-info && \
+    echo "✅ Runtime Python compatibility packages refreshed"
 
 # Copy Playwright browsers from build stage to Lambda task root
 # The browsers were installed in the build stage using the official Playwright image

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ description = "Instagram link unfurl service for Slack"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "requests>=2.31.0",
-    "httpx[http2]>=0.24.1",
+    "requests>=2.34.2",
+    "httpx[http2]>=0.28.1",
     "beautifulsoup4>=4.12.2",
     "aws-lambda-powertools[parser]>=2.31.0",
     "boto3>=1.34.0",
@@ -16,11 +16,11 @@ dependencies = [
     "typing-extensions>=4.7.0",
     "wrapt>=1.16.0",
     "annotated-types>=0.5.0",
-    "orjson>=3.10.12",
+    "orjson>=3.11.9",
     "python-dotenv>=0.21.0",
     "cachetools>=5.5.0",
     "python-dateutil>=2.8.2",
-    "aiohttp>=3.12.6",  # Required by slack-sdk AsyncWebClient
+    "aiohttp>=3.13.5",  # Required by slack-sdk AsyncWebClient
     "logfire[aws-lambda]==4.1.0",
     "opentelemetry-api>=1.22.0",
 ]

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -5,24 +5,25 @@ boto3==1.34.34
 slack-sdk==3.26.2
 
 # HTTP dependencies (wheel-compatible versions)
-requests==2.31.0
-httpx[http2]==0.26.0
+requests==2.34.2
+httpx[http2]==0.28.1
+urllib3==2.7.0
 # Required by slack-sdk AsyncWebClient for concurrent processing
-aiohttp==3.12.6
+aiohttp==3.13.5
 
 # Scraping dependencies
-beautifulsoup4==4.12.3
-lxml==5.3.0
-soupsieve==2.4.0
+beautifulsoup4==4.14.3
+lxml==6.1.1
+soupsieve==2.8.3
 
 # Additional utilities (ARM64 wheel compatible)
-cachetools==5.5.0
-python-dateutil==2.8.2
-typing-extensions==4.7.0
-wrapt==1.16.0
-annotated-types==0.5.0
+cachetools==7.1.2
+python-dateutil==2.9.0.post0
+typing-extensions==4.15.0
+wrapt==1.17.3
+annotated-types==0.7.0
 # Use newer orjson version that has ARM64 wheels
-orjson==3.10.12
+orjson==3.11.9
 
 # Observability (Logfire)
 # Only pin logfire; its [aws-lambda] extras pick a consistent opentelemetry-*
@@ -31,8 +32,8 @@ orjson==3.10.12
 logfire[aws-lambda]==4.1.0
 
 # Performance and browser automation (optional but recommended)
-uvloop==0.19.0
-playwright==1.45.0
+uvloop==0.22.1
+playwright==1.60.0
 playwright-stealth==1.0.6
 # Ensure modern packaging tools are available to avoid pkg_resources warnings
-setuptools>=68.0.0
+setuptools==82.0.1

--- a/requirements-event-router.txt
+++ b/requirements-event-router.txt
@@ -5,10 +5,11 @@ boto3==1.34.34
 aws-lambda-powertools[parser]==2.32.0
 
 # Additional lightweight dependencies
-requests==2.31.0
-python-dateutil==2.8.2
-typing-extensions==4.7.0
-wrapt==1.16.0
+requests==2.34.2
+urllib3==2.7.0
+python-dateutil==2.9.0.post0
+typing-extensions==4.15.0
+wrapt==1.17.3
 
 # Observability (Logfire)
 # Only pin logfire; let its [aws-lambda] extras resolve the opentelemetry-*


### PR DESCRIPTION
## Summary
- Refreshes pinned Lambda/runtime dependencies to patched versions for `requests`, `aiohttp`, `lxml`, `orjson`, `urllib3`, and related support packages.
- Upgrades the Playwright builder/browser image and Python package from `1.45.0-jammy` to `1.60.0-noble`.
- Refreshes runtime OS packages and removes the vulnerable base `urllib3` copy after installing the patched package into `/var/task`.

## Security impact
- `pip-audit` on both Lambda requirements files reports 0 known vulnerabilities.
- Final Trivy image scan improved from 59 high / 0 critical to 20 high / 0 critical.
- Remaining Trivy findings are Amazon Linux `nss/nspr` and `python3-pip` RPMs whose scanner-fixed versions are not currently available via the enabled Lambda base image repos.

## Test plan
- `uv run pytest` (77 passed, 5 skipped by existing CDK test gate)
- `docker build --pull --platform linux/arm64 -t unfurl-service:audit .`
- `trivy image --scanners vuln --severity CRITICAL,HIGH unfurl-service:audit`
- `grype unfurl-service:audit`


Made with [Cursor](https://cursor.com)