### PR TITLE
fix(scraper): stop treating Instagram login wall as successful scrape

### DIFF
--- a/src/unfurl_processor/scrapers/http_scraper.py
+++ b/src/unfurl_processor/scrapers/http_scraper.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 from bs4 import BeautifulSoup
 
+from ..url_utils import is_instagram_login_url, is_instagram_static_asset_url
 from .base import BaseScraper, ScrapingResult
 
 
@@ -108,6 +109,21 @@ class HttpScraper(BaseScraper):
                 # Step 2: Navigate to target URL
                 response = await client.get(url)
                 response.raise_for_status()
+
+            # Instagram 302s bot-flagged/anonymous requests to the login
+            # page; the response is 200 OK but contains no post data.
+            final_url = str(response.url)
+            if is_instagram_login_url(final_url):
+                self.logger.warning(
+                    f"Redirected to Instagram login wall for {url} "
+                    f"(final URL: {final_url})"
+                )
+                return ScrapingResult(
+                    success=False,
+                    error="Redirected to Instagram login page (bot detection)",
+                    method=self.name,
+                    response_time_ms=self.measure_time(start_time),
+                )
 
             # Log response details for debugging
             self.logger.info(f"Response status: {response.status_code}")
@@ -283,14 +299,23 @@ class HttpScraper(BaseScraper):
                 if content_type == "photo":
                     content_type = "video"
 
+            image_url = (
+                og_image.get("content")
+                if og_image
+                else twitter_image.get("content") if twitter_image else None
+            )
+            # Reject static site assets (e.g. the Instagram logo served on
+            # login/error pages) — they are not post media.
+            if image_url and is_instagram_static_asset_url(image_url):
+                self.logger.warning(
+                    f"Ignoring static Instagram asset as image: {image_url}"
+                )
+                image_url = None
+
             data = {
                 "post_id": self.extract_post_id(url),
                 "url": url,
-                "image_url": (
-                    og_image.get("content")
-                    if og_image
-                    else twitter_image.get("content") if twitter_image else None
-                ),
+                "image_url": image_url,
                 "video_url": video_url,
                 "title": (
                     og_title.get("content")
@@ -324,11 +349,14 @@ class HttpScraper(BaseScraper):
             # Try to extract enhanced data
             self._extract_enhanced_data(soup, data)
 
-            # Only return data if we have essential metadata
+            # Only return data if we have real post content: media, or
+            # parsed author/caption. A bare description with nothing else
+            # is typical of login/error pages and produces junk unfurls.
             if (
                 data.get("image_url")
                 or data.get("video_url")
-                or data.get("description")
+                or data.get("username")
+                or data.get("caption")
             ):
                 return data
 

--- a/src/unfurl_processor/scrapers/playwright_scraper.py
+++ b/src/unfurl_processor/scrapers/playwright_scraper.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Optional
 
 from bs4 import BeautifulSoup
 
+from ..url_utils import is_instagram_login_url, is_instagram_static_asset_url
 from .base import BaseScraper, ScrapingResult
 
 # Enhanced Playwright import with comprehensive debugging
@@ -324,6 +325,20 @@ class PlaywrightScraper(BaseScraper):
             # Navigate with realistic timing
             await page.goto(url, wait_until="domcontentloaded")
 
+            # Fail fast if Instagram bounced us to the login wall — there is
+            # no post metadata there, so waiting for selectors is pointless.
+            if is_instagram_login_url(page.url):
+                self.logger.warning(
+                    f"Redirected to Instagram login wall for {url} "
+                    f"(final URL: {page.url})"
+                )
+                return ScrapingResult(
+                    success=False,
+                    error="Redirected to Instagram login page (bot detection)",
+                    method=self.name,
+                    response_time_ms=self.measure_time(start_time),
+                )
+
             # Wait for content to load with timeout (check for presence, not visibility)
             try:
                 await page.wait_for_selector(
@@ -453,11 +468,22 @@ class PlaywrightScraper(BaseScraper):
                 # Try to parse likes and comments from description
                 self._parse_engagement_data(description, data)
 
-            # Extract media URLs
+            # Extract media URLs (rejecting static site assets like the
+            # Instagram logo served on login/error pages)
+            image_url = None
             if og_image and og_image.get("content"):
-                data["image_url"] = og_image.get("content")
+                image_url = og_image.get("content")
             elif twitter_image and twitter_image.get("content"):
-                data["image_url"] = twitter_image.get("content")
+                image_url = twitter_image.get("content")
+
+            if image_url and is_instagram_static_asset_url(image_url):
+                self.logger.warning(
+                    f"Ignoring static Instagram asset as image: {image_url}"
+                )
+                image_url = None
+
+            if image_url:
+                data["image_url"] = image_url
 
             # Extract video URL for reels/videos
             video_url = None
@@ -488,9 +514,12 @@ class PlaywrightScraper(BaseScraper):
             # Extract additional data from page JavaScript and elements
             self._extract_enhanced_page_data(soup, data)
 
-            # Ensure we have at least basic data
+            # Ensure we have real post content: media or author/caption.
+            # A generic title alone (e.g. "Instagram" on the login page)
+            # is not enough to build a useful unfurl.
             if not any(
-                key in data for key in ["title", "caption", "image_url", "video_url"]
+                data.get(key)
+                for key in ["username", "caption", "image_url", "video_url"]
             ):
                 return None
 

--- a/src/unfurl_processor/slack_formatter.py
+++ b/src/unfurl_processor/slack_formatter.py
@@ -36,6 +36,15 @@ class SlackFormatter:
         if not data:
             return None
 
+        # Refuse to build placeholder unfurls: without an author, caption,
+        # or any media there is nothing useful to show, and a bare link is
+        # better than a generic "Instagram User" card.
+        if not self._has_meaningful_content(data):
+            self.logger.info(
+                "Skipping unfurl: no meaningful Instagram content extracted"
+            )
+            return None
+
         try:
             is_fallback = data.get("is_fallback", False)
             # Prefer video path when applicable
@@ -51,6 +60,12 @@ class SlackFormatter:
         except Exception as e:
             self.logger.warning(f"Failed to format unfurl data: {e}")
             return self._format_basic_unfurl(data)
+
+    def _has_meaningful_content(self, data: Dict[str, Any]) -> bool:
+        """Check that scraped data contains real post content."""
+        return any(
+            data.get(key) for key in ("username", "caption", "image_url", "video_url")
+        )
 
     def _format_video_content_unfurl(
         self, data: Dict[str, Any], is_fallback: bool

--- a/src/unfurl_processor/url_utils.py
+++ b/src/unfurl_processor/url_utils.py
@@ -126,6 +126,69 @@ def validate_instagram_url(url: str) -> bool:
     return _get_instagram_media_parts(url) is not None
 
 
+def is_instagram_login_url(url: str) -> bool:
+    """
+    Check if URL is Instagram's login/challenge wall.
+
+    Instagram redirects anonymous or bot-flagged requests to
+    /accounts/login/?next=... — reaching this page means scraping failed,
+    even though the HTTP response is 200 OK.
+
+    Args:
+        url: Final URL after redirects
+
+    Returns:
+        True if URL is a login or challenge page
+    """
+    parsed_url = _get_parsed_instagram_url(url)
+    if parsed_url is None:
+        return False
+
+    parsed, hostname = parsed_url
+    if not _is_instagram_hostname(hostname):
+        return False
+
+    path = parsed.path.lower()
+    return path.startswith("/accounts/login") or path.startswith("/challenge")
+
+
+def is_instagram_static_asset_url(url: str) -> bool:
+    """
+    Check if URL points to a static Instagram site asset (logos, icons, UI
+    sprites) rather than real post media.
+
+    The login page advertises the Instagram logo
+    (e.g. static.cdninstagram.com/rsrc.php/...) which must never be used as
+    a post image. Real post media lives on scontent-*.cdninstagram.com or
+    *.fbcdn.net and never under /rsrc.php or /static/.
+
+    Args:
+        url: Image or video URL to check
+
+    Returns:
+        True if URL is a static site asset, not post media
+    """
+    if not isinstance(url, str) or not url:
+        return False
+
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return False
+
+    hostname = (parsed.hostname or "").lower()
+    path = parsed.path.lower()
+
+    if hostname == "static.cdninstagram.com":
+        return True
+    if "/rsrc.php/" in path or path.startswith("/rsrc.php"):
+        return True
+    if _is_instagram_hostname(hostname) and path.startswith("/static/"):
+        return True
+
+    return False
+
+
 def is_instagram_video_url(url: str) -> bool:
     """
     Check if URL is likely an Instagram video URL.

--- a/tests/test_url_utils.py
+++ b/tests/test_url_utils.py
@@ -5,6 +5,8 @@ from src.unfurl_processor.url_utils import (
     extract_instagram_id,
     get_cache_key,
     get_cache_ttl,
+    is_instagram_login_url,
+    is_instagram_static_asset_url,
     is_instagram_video_url,
     validate_instagram_url,
 )
@@ -158,6 +160,71 @@ class TestIsInstagramVideoUrl:
         """Test handling of empty URL."""
         assert not is_instagram_video_url("")
         assert not is_instagram_video_url(None)
+
+
+class TestIsInstagramLoginUrl:
+    """Tests for is_instagram_login_url function."""
+
+    def test_login_redirect_url(self):
+        """Login wall URLs (bot detection redirect target) are detected."""
+        url = (
+            "https://www.instagram.com/accounts/login/"
+            "?next=https%3A%2F%2Fwww.instagram.com%2Freel%2FABC123&is_from_rle"
+        )
+        assert is_instagram_login_url(url)
+
+    def test_challenge_url(self):
+        """Challenge/checkpoint URLs are detected."""
+        assert is_instagram_login_url("https://www.instagram.com/challenge/")
+
+    def test_post_url_not_login(self):
+        """Regular media URLs are not flagged."""
+        assert not is_instagram_login_url("https://www.instagram.com/p/ABC123/")
+        assert not is_instagram_login_url("https://www.instagram.com/reel/XYZ456/")
+
+    def test_non_instagram_login_not_flagged(self):
+        """Login paths on other domains are ignored."""
+        assert not is_instagram_login_url("https://example.com/accounts/login/")
+
+    def test_invalid_input(self):
+        """Invalid input is handled gracefully."""
+        assert not is_instagram_login_url("")
+        assert not is_instagram_login_url(None)
+
+
+class TestIsInstagramStaticAssetUrl:
+    """Tests for is_instagram_static_asset_url function."""
+
+    def test_login_page_logo_rejected(self):
+        """The Instagram logo served on the login page is a static asset."""
+        url = "https://static.cdninstagram.com/rsrc.php/v4/yD/r/R0fBIMurK8v.png"
+        assert is_instagram_static_asset_url(url)
+
+    def test_favicon_rejected(self):
+        """Instagram favicon under /static/ is a static asset."""
+        url = (
+            "https://www.instagram.com/static/images/ico/"
+            "favicon-192.png/68d99ba29cc8.png"
+        )
+        assert is_instagram_static_asset_url(url)
+
+    def test_real_post_media_allowed(self):
+        """Real post media on scontent CDN is not a static asset."""
+        url = (
+            "https://scontent-iad3-1.cdninstagram.com/v/t51.2885-15/"
+            "12345_n.jpg?stp=dst-jpg"
+        )
+        assert not is_instagram_static_asset_url(url)
+
+    def test_fbcdn_media_allowed(self):
+        """Video media on fbcdn is not a static asset."""
+        url = "https://video-iad3-1.xx.fbcdn.net/v/t50.2886-16/video.mp4"
+        assert not is_instagram_static_asset_url(url)
+
+    def test_invalid_input(self):
+        """Invalid input is handled gracefully."""
+        assert not is_instagram_static_asset_url("")
+        assert not is_instagram_static_asset_url(None)
 
 
 class TestGetCacheKey:

--- a/tests/unit/test_http_scraper.py
+++ b/tests/unit/test_http_scraper.py
@@ -13,9 +13,7 @@ class TestHttpScraperBehavior:
         from unfurl_processor.scrapers.http_scraper import HttpScraper
 
         scraper = HttpScraper()
-        result = asyncio.get_event_loop().run_until_complete(
-            scraper.scrape("https://example.com/not-instagram")
-        )
+        result = asyncio.run(scraper.scrape("https://example.com/not-instagram"))
 
         assert result.success is False
         assert "Invalid Instagram URL" in result.error
@@ -38,7 +36,7 @@ class TestHttpScraperBehavior:
             await scraper.scrape("https://www.instagram.com/p/TEST123/")
             await bg
 
-        asyncio.get_event_loop().run_until_complete(run_test())
+        asyncio.run(run_test())
         assert len(completed_flag) == 1, "Background task should have completed"
 
     def test_scrape_uses_async_http_not_requests(self):
@@ -77,9 +75,7 @@ class TestHttpScraperBehavior:
             "unfurl_processor.scrapers.http_scraper.httpx.AsyncClient",
             return_value=client,
         ):
-            result = asyncio.get_event_loop().run_until_complete(
-                scraper.scrape(post_url)
-            )
+            result = asyncio.run(scraper.scrape(post_url))
 
         assert result.success is False
         assert "login" in result.error.lower()

--- a/tests/unit/test_http_scraper.py
+++ b/tests/unit/test_http_scraper.py
@@ -1,6 +1,10 @@
 """Tests for HttpScraper async behavior."""
 
 import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+from bs4 import BeautifulSoup
 
 
 class TestHttpScraperBehavior:
@@ -42,3 +46,86 @@ class TestHttpScraperBehavior:
         import unfurl_processor.scrapers.http_scraper as mod
 
         assert not hasattr(mod, "requests"), "Should not use synchronous requests"
+
+    def test_scrape_fails_on_login_redirect(self):
+        """A redirect to the Instagram login wall must fail the scrape.
+
+        Instagram 302s bot-flagged requests to /accounts/login/?next=...
+        which returns 200 OK but contains no post data. Treating it as
+        success produced placeholder unfurls with the Instagram logo.
+        """
+        from unfurl_processor.scrapers.http_scraper import HttpScraper
+
+        scraper = HttpScraper()
+        post_url = "https://www.instagram.com/reel/ABC123/"
+        login_url = (
+            "https://www.instagram.com/accounts/login/"
+            "?next=https%3A%2F%2Fwww.instagram.com%2Freel%2FABC123&is_from_rle"
+        )
+
+        login_response = MagicMock(spec=httpx.Response)
+        login_response.url = httpx.URL(login_url)
+        login_response.status_code = 200
+        login_response.raise_for_status = MagicMock()
+
+        client = AsyncMock()
+        client.get = AsyncMock(return_value=login_response)
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "unfurl_processor.scrapers.http_scraper.httpx.AsyncClient",
+            return_value=client,
+        ):
+            result = asyncio.get_event_loop().run_until_complete(
+                scraper.scrape(post_url)
+            )
+
+        assert result.success is False
+        assert "login" in result.error.lower()
+
+
+class TestHttpScraperExtraction:
+    def test_static_asset_image_is_rejected(self):
+        """The Instagram logo from login/error pages must not become the
+        post image."""
+        from unfurl_processor.scrapers.http_scraper import HttpScraper
+
+        html = """
+        <html><head>
+        <meta property="og:image"
+              content="https://static.cdninstagram.com/rsrc.php/v4/yD/r/logo.png" />
+        </head><body></body></html>
+        """
+        scraper = HttpScraper()
+        soup = BeautifulSoup(html, "html.parser")
+        data = scraper._extract_instagram_data(
+            soup, "https://www.instagram.com/reel/ABC123/"
+        )
+
+        # No real media, username, or caption -> no data at all
+        assert data is None
+
+    def test_real_post_media_is_kept(self):
+        """Real scontent CDN media should still be extracted."""
+        from unfurl_processor.scrapers.http_scraper import HttpScraper
+
+        html = """
+        <html><head>
+        <meta property="og:image"
+              content="https://scontent-iad3-1.cdninstagram.com/v/t51/photo.jpg" />
+        <meta property="og:description"
+              content="123 Likes, 45 Comments - someuser on Instagram" />
+        </head><body></body></html>
+        """
+        scraper = HttpScraper()
+        soup = BeautifulSoup(html, "html.parser")
+        data = scraper._extract_instagram_data(
+            soup, "https://www.instagram.com/p/ABC123/"
+        )
+
+        assert data is not None
+        assert (
+            data["image_url"]
+            == "https://scontent-iad3-1.cdninstagram.com/v/t51/photo.jpg"
+        )

--- a/tests/unit/test_playwright_scraper.py
+++ b/tests/unit/test_playwright_scraper.py
@@ -38,7 +38,7 @@ class TestPlaywrightScraperLifecycle:
         scraper.context = AsyncMock()
         scraper.is_initialized = True
 
-        asyncio.get_event_loop().run_until_complete(scraper.cleanup())
+        asyncio.run(scraper.cleanup())
 
         assert driver.stopped is True
         assert scraper._playwright_driver is None
@@ -52,7 +52,7 @@ class TestPlaywrightScraperLifecycle:
 
         scraper = PlaywrightScraper()
         # Should not raise
-        asyncio.get_event_loop().run_until_complete(scraper.cleanup())
+        asyncio.run(scraper.cleanup())
         assert scraper.is_initialized is False
 
     def test_driver_reference_stored_on_instance(self):

--- a/tests/unit/test_slack_formatter.py
+++ b/tests/unit/test_slack_formatter.py
@@ -32,3 +32,40 @@ def test_video_host_validation_rejects_untrusted_fcdn_domains() -> None:
 
     assert formatter._is_instagram_video_url("https://video.xx.fbcdn.net/video.mp4")
     assert not formatter._is_instagram_video_url("https://attacker.fcdn.us/video.mp4")
+
+
+def test_format_unfurl_returns_none_without_meaningful_content() -> None:
+    """Data without author, caption, or media must not produce a
+    placeholder unfurl (e.g. 'Instagram User' + Instagram logo)."""
+    formatter = SlackFormatter()
+
+    unfurl = formatter.format_unfurl_data(
+        {
+            "url": "https://www.instagram.com/reel/ABC123/",
+            "content_type": "reel",
+            "is_video": True,
+            "title": "Instagram",
+            "username": None,
+            "caption": None,
+            "image_url": None,
+            "video_url": None,
+        }
+    )
+
+    assert unfurl is None
+
+
+def test_format_unfurl_still_works_with_image_only() -> None:
+    """Real media without a username should still unfurl."""
+    formatter = SlackFormatter()
+
+    unfurl = formatter.format_unfurl_data(
+        {
+            "url": "https://www.instagram.com/p/ABC123/",
+            "content_type": "photo",
+            "image_url": "https://scontent.cdninstagram.com/image.jpg",
+        }
+    )
+
+    assert unfurl is not None
+    assert "blocks" in unfurl


### PR DESCRIPTION
## Summary

Instagram has started 302-redirecting the Lambda's anonymous requests to `/accounts/login/?next=...`. The HTTP scraper followed the redirect, parsed the **login page** as if it were the post, and shipped placeholder unfurls to Slack — "Instagram User", "Instagram Reel", and the 779 kB Instagram logo (`static.cdninstagram.com/rsrc.php/...`) as the "post image" — which were then cached in DynamoDB for 24h. Root cause verified via CloudWatch logs for the invocation that unfurled reel `DaLeD5kB6yK` and by inspecting the persisted CloudFront asset (4168x4168 Instagram logo, content-length 778568 = the "779 kB" in the broken card).

## Changes

Four layers of defense:

1. **Login-wall detection** — new `is_instagram_login_url()` helper; `HttpScraper` checks the final URL after redirects and fails with a clear error; `PlaywrightScraper` checks `page.url` right after navigation (also fails in ms instead of a 5s selector timeout).
2. **Static-asset image filtering** — new `is_instagram_static_asset_url()` helper rejects `static.cdninstagram.com`, `/rsrc.php/`, and `instagram.com/static/` URLs as post media in both scrapers. Real media on `scontent-*.cdninstagram.com` / `*.fbcdn.net` is unaffected.
3. **Stricter extraction gates** — both scrapers only return data when there is real content (media, username, or caption); a bare description or generic "Instagram" title no longer counts as success.
4. **Formatter gate** — `SlackFormatter.format_unfurl_data` returns `None` for data with no username/caption/media, so no placeholder unfurl is sent and nothing junk is cached.

Net effect: when Instagram login-walls us, users see their plain link instead of a broken placeholder card, and bad results can no longer be cached.

Note: this makes failures honest but does not defeat the login wall itself — for that we'd need proxies (`PROXY_URLS` is already supported), an authenticated session, or the oEmbed/Graph API. Container Lambda, so a deploy/image rebuild is required for the fix to take effect.

## Test plan

- [x] 14 new unit tests: login URL detection, static-asset filtering, HTTP scraper redirect rejection (mocked httpx with the exact production redirect), logo-rejection vs real-media extraction, formatter meaningful-content gate
- [x] Full suite: 99 passed, 5 skipped (CDK tests, expected)
- [x] `black`, `flake8`, `mypy` clean

Made with [Cursor](https://cursor.com)