### PR TITLE
chore(cdk): bump CDK CLI to 2.1129.0 for schema 54 compatibility

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "aws-cdk": "^2.1122.0"
+        "aws-cdk": "^2.1129.0"
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1122.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1122.0.tgz",
-      "integrity": "sha512-AI2Ks9qioWLvBPD4IoEtTet3wUG/o/q6U3WR3VCQKH5sNYLLPALo8o9sermNpMnfd1OQkqhL20tp4cEyojrIZg==",
+      "version": "2.1129.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1129.0.tgz",
+      "integrity": "sha512-M0EWbjeKW+baUsirjtKuWh7w/9dPxF8taEi2hqo9ecCjGeQxV1dzyosJf+caR3Jh7dFyyT3J8zEtRb/cU971Rw==",
       "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "aws-cdk": "^2.1122.0"
+    "aws-cdk": "^2.1129.0"
   }
 }


### PR DESCRIPTION
## Summary

- The deploy workflow failed on main after merging #62: `Cloud assembly schema version mismatch: Maximum schema version supported is 53.x.x, but found 54.0.0. You need at least CLI version 2.1129.0`.
- `aws-cdk-lib` (installed unpinned-latest via `uv pip install -e ".[cdk]"`) now emits cloud assembly schema 54, but the CDK CLI in `cdk/package.json` was locked to 2.1122.0 which only reads schema 53.
- Bumps `aws-cdk` to `^2.1129.0` so the CLI can read the manifest and the deploy of the login-wall fix (#62) can go out.

## Test plan

- [x] `uv run pytest` — 99 passed, 5 skipped
- [ ] Deploy workflow on main succeeds after merge

Made with [Cursor](https://cursor.com)